### PR TITLE
Add nemo_id + nemo_pfix in class writer itself

### DIFF
--- a/man/Tool.Rd
+++ b/man/Tool.Rd
@@ -14,9 +14,9 @@ x <- Tool$new("tool1", pkg = "nemo", path = path)
 x <- Tool1$new(path = path)$
   filter_files(exclude = "alignments_dupfreq")$
   tidy(keep_raw = TRUE)
-a$tbls
-a$files
-a$list_files()
+x$tbls
+x$files
+x$list_files()
 lx <- Linx$new(path)
 dbconn <- DBI::dbConnect(
   drv = RPostgres::Postgres(),

--- a/man/nemo_write.Rd
+++ b/man/nemo_write.Rd
@@ -4,14 +4,7 @@
 \alias{nemo_write}
 \title{Write data}
 \usage{
-nemo_write(
-  d,
-  fpfix = NULL,
-  format = "tsv",
-  id = NULL,
-  dbconn = NULL,
-  dbtab = NULL
-)
+nemo_write(d, fpfix = NULL, format = "tsv", dbconn = NULL, dbtab = NULL)
 }
 \arguments{
 \item{d}{(\code{data.frame()})\cr
@@ -23,9 +16,6 @@ argument. For a format of db, this is inserted into the \code{nemo_pfix} column.
 
 \item{format}{(\code{character(1)})\cr
 Output format. One of tsv, csv, parquet, rds, or db.}
-
-\item{id}{(\code{character(1)})\cr
-ID to use in the first \code{nemo_id} column for this table.}
 
 \item{dbconn}{(\code{DBIConnection(1)})\cr
 Database connection object (see \code{DBI::dbConnect}). Used only when format is db.}
@@ -40,14 +30,13 @@ Writes tabular data in the given format.
 d <- tibble::tibble(name = "foo", data = 123)
 fpfix <- file.path(tempdir(), "data_test1")
 format <- "csv"
-id <- "run1"
-nemo_write(d = d, fpfix = fpfix, format = format, id = id)
+nemo_write(d = d, fpfix = fpfix, format = format)
 (res <- readr::read_csv(glue::glue("{fpfix}.csv.gz"), show_col_types = FALSE))
 \dontshow{if (RPostgres::postgresHasDefault()) withAutoprint(\{ # examplesIf}
 # for database writing
 con <- DBI::dbConnect(RPostgres::Postgres())
 tbl_nm <- "awesome_tbl"
-nemo_write(d = d, fpfix = basename(fpfix), format = "db", id = "123", dbconn = con, dbtab = tbl_nm)
+nemo_write(d = d, fpfix = basename(fpfix), format = "db", dbconn = con, dbtab = tbl_nm)
 DBI::dbListTables(con)
 DBI::dbReadTable(con, tbl_nm)
 DBI::dbDisconnect(con)

--- a/tests/testthat/test-roxytest-testexamples-write.R
+++ b/tests/testthat/test-roxytest-testexamples-write.R
@@ -2,19 +2,18 @@
 
 # File R/write.R: @testexamples
 
-test_that("Function nemo_write() @ L37", {
+test_that("Function nemo_write() @ L34", {
   
   d <- tibble::tibble(name = "foo", data = 123)
   fpfix <- file.path(tempdir(), "data_test1")
   format <- "csv"
-  id <- "run1"
-  nemo_write(d = d, fpfix = fpfix, format = format, id = id)
+  nemo_write(d = d, fpfix = fpfix, format = format)
   (res <- readr::read_csv(glue::glue("{fpfix}.csv.gz"), show_col_types = FALSE))
   expect_equal(nrow(res), 1)
 })
 
 
-test_that("Function valid_out_fmt() @ L89", {
+test_that("Function valid_out_fmt() @ L81", {
   
   valid_out_fmt("tsv")
   expect_true(valid_out_fmt("tsv"))


### PR DESCRIPTION
We now get `nemo_pfix` in non-db formats as well e.g.


```
SELECT * FROM "sampleA_2_tool1_table1.parquet";
┌─────────┬───────────┬───────────┬────────────┬───────┬───────┬──────────┬──────────┬──────────┐
│ nemo_id │ nemo_pfix │ sample_id │ chromosome │ start │  end  │ metric_x │ metric_y │ metric_z │
│ varchar │  varchar  │  varchar  │  varchar   │ int32 │ int32 │  double  │  double  │  double  │
├─────────┼───────────┼───────────┼────────────┼───────┼───────┼──────────┼──────────┼──────────┤
│ abc123  │ sampleA_2 │ sampleA   │ chr1       │    10 │    50 │      0.1 │      0.4 │      0.7 │
│ abc123  │ sampleA_2 │ sampleA   │ chr2       │   100 │   500 │      0.2 │      0.5 │      0.8 │
│ abc123  │ sampleA_2 │ sampleA   │ chr3       │  1000 │  5000 │      0.3 │      0.6 │      0.9 │
└─────────┴───────────┴───────────┴────────────┴───────┴───────┴──────────┴──────────┴──────────┘
D
```

Fixes #18.