### PR TITLE
list_files: str_remove offers more flexibility

### DIFF
--- a/R/Tool.R
+++ b/R/Tool.R
@@ -182,7 +182,7 @@ Tool <- R6::R6Class(
       }
       res |>
         dplyr::mutate(
-          prefix = stringr::str_replace(.data$bname, glue("(.*){.data$pattern}"), "\\1"),
+          prefix = stringr::str_remove(.data$bname, .data$pattern),
           # handle wigits version files
           prefix = dplyr::if_else(
             .data$parser == "version" & .data$prefix == "",


### PR DESCRIPTION
Fixes #23.

- Before:

```
> stringr::str_replace("L2001005.duplicate_freq.tsv", glue::glue("(\\.*)\\.duplicate_freq\\.tsv$"), "\\1")
[1] "L2001005"
> stringr::str_replace("L2001005.redux.duplicate_freq.tsv", glue::glue("(\\.*)\\.duplicate_freq\\.tsv$"), "\\1")
[1] "L2001005.redux"

# even this doesn't work as intended
stringr::str_replace("L2001005.redux.duplicate_freq.tsv", glue::glue("(\\.redux)?\\.duplicate_freq\\.tsv$"), "\\1")
[1] "L2001005.redux"
```

- Now:

```
> stringr::str_remove("L2001005.redux.duplicate_freq.tsv", "(\\.redux)?\\.duplicate_freq\\.tsv$")
[1] "L2001005"
> stringr::str_remove("L2001005.duplicate_freq.tsv", "(\\.redux)?\\.duplicate_freq\\.tsv$")
[1] "L2001005"
```