### PR TITLE
GHA: add GHA-based version bumping workflow

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -1,0 +1,19 @@
+name: Bump Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'New version (e.g. 0.1.0)'
+        required: true
+        type: string
+
+jobs:
+  bump:
+    uses: tidywf/.github/.github/workflows/bump.yaml@main
+    permissions:
+      contents: write
+    with:
+      pkg_name: nemo
+      pkg_version: ${{ inputs.version }}
+    secrets: inherit


### PR DESCRIPTION
Copying this to main so that I can use in dev (see #44).