### PR TITLE
metadata: export as parquet to result dir

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,6 @@ Imports:
     dplyr,
     fs,
     glue,
-    jsonlite,
     knitr,
     log4r,
     purrr,

--- a/R/Workflow.R
+++ b/R/Workflow.R
@@ -204,9 +204,8 @@ Workflow <- R6::R6Class(
       # Write metadata
       if (format != "db" && !is.null(res)) {
         diro <- normalizePath(diro)
-        meta_diro <- file.path(diro, "_metadata") |> fs::dir_create()
         meta <- self$get_metadata(input_id = input_id, output_id = output_id, output_dir = diro)
-        jsonlite::write_json(meta, file.path(meta_diro, "metadata.json"), pretty = TRUE)
+        arrow::write_parquet(meta, file.path(diro, "metadata.parquet"))
       }
       return(invisible(self))
     },
@@ -292,9 +291,9 @@ Workflow <- R6::R6Class(
     #' Output directory.
     #' @param pkgs (`character(n)`)\cr
     #' Which R packages to extract versions for.
-    #' @return (`list()`)\cr
-    #' List with `input_id`, `output_id`, `input_dirs`, `output_dir`,
-    #' `pkg_versions`, and `files`.
+    #' @return (`tibble()`)\cr
+    #' Single-row tibble with columns `input_id`, `output_id`, `input_dirs`,
+    #' `output_dir`, `pkg_versions`, and `files`.
     get_metadata = function(input_id, output_id, output_dir, pkgs = NULL) {
       if (is.null(pkgs)) {
         pkgs <- self$metapkg
@@ -305,11 +304,14 @@ Workflow <- R6::R6Class(
         # it's a flat output structure.
         files <- self$written_files |>
           dplyr::mutate(outpath = basename(.data$outpath)) |>
-          dplyr::select(tbl = "tbl_name", "prefix", fout = "outpath", fin = "raw_path")
+          dplyr::select(tbl = "tbl_name", "prefix", fout = "outpath", fin = "raw_path") |>
+          # Arrow treats glue/fs_byte as an extension type and refuses to write_parquet
+          dplyr::mutate(dplyr::across(dplyr::where(is.character), as.character))
       } else {
         # just select raw path and size
         files <- self$files_tbl |>
-          dplyr::select(fin = "path", "size")
+          dplyr::select(fin = "path", "size") |>
+          dplyr::mutate(size = as.numeric(.data$size))
       }
       meta <- nemo_metadata(
         files = files,

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -13,7 +13,8 @@
 #' @param output_dir (`character(1)`)\cr
 #' Output directory.
 #'
-#' @returns List of metadata.
+#' @returns Single-row tibble of metadata with list columns for `input_dirs`,
+#'   `pkg_versions`, and `files`.
 #'
 #' @examples
 #' files <- tibble::tibble(
@@ -43,15 +44,14 @@ nemo_metadata <- function(files, pkgs, input_id, output_id, input_dirs, output_d
     dplyr::rowwise() |>
     dplyr::mutate(version = as.character(utils::packageVersion(.data$name))) |>
     dplyr::ungroup()
-  # handle NULLs
   input_id <- input_id %||% NA_character_
   output_id <- output_id %||% NA_character_
-  list(
-    input_id = jsonlite::unbox(input_id),
-    output_id = jsonlite::unbox(output_id),
-    input_dirs = I(input_dirs),
-    output_dir = jsonlite::unbox(output_dir),
-    pkg_versions = pkg_versions,
-    files = files
+  tibble::tibble(
+    input_id = input_id,
+    output_id = output_id,
+    input_dirs = list(input_dirs),
+    output_dir = output_dir,
+    pkg_versions = list(as.data.frame(pkg_versions)),
+    files = list(as.data.frame(files))
   )
 }

--- a/man/Workflow.Rd
+++ b/man/Workflow.Rd
@@ -371,9 +371,9 @@ Which R packages to extract versions for.}
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-(\code{list()})\cr
-List with \code{input_id}, \code{output_id}, \code{input_dirs}, \code{output_dir},
-\code{pkg_versions}, and \code{files}.
+(\code{tibble()})\cr
+Single-row tibble with columns \code{input_id}, \code{output_id}, \code{input_dirs},
+\code{output_dir}, \code{pkg_versions}, and \code{files}.
 }
 }
 \if{html}{\out{<hr>}}

--- a/man/cli_tidy_parse_args.Rd
+++ b/man/cli_tidy_parse_args.Rd
@@ -9,7 +9,7 @@ cli_tidy_parse_args(args, wf = NULL)
 \arguments{
 \item{args}{Named list of parsed CLI arguments, as returned by argparse.
 Expected fields: \code{format}, \code{in_dir}, \code{out_dir}, \code{input_id} (optional),
-\code{output_id} (optional), \code{ulid}, \code{pfix_include}, \code{dbname}, \code{dbuser},
+\code{output_id} (optional), \code{ulid}, \code{prefix_include}, \code{dbname}, \code{dbuser},
 \code{include}, \code{exclude}, \code{workflow} (may be \code{NULL} when \code{wf} is provided),
 \code{quiet}.
 \code{output_id} and \code{ulid} are mutually exclusive at the CLI level (enforced by

--- a/man/nemo_metadata.Rd
+++ b/man/nemo_metadata.Rd
@@ -25,7 +25,8 @@ Input directory (can be multiple).}
 Output directory.}
 }
 \value{
-List of metadata.
+Single-row tibble of metadata with list columns for \code{input_dirs},
+\code{pkg_versions}, and \code{files}.
 }
 \description{
 Assemble run metadata

--- a/tests/testthat/test-roxytest-testexamples-Config.R
+++ b/tests/testthat/test-roxytest-testexamples-Config.R
@@ -45,7 +45,7 @@ test_that("Function Config() @ L57", {
 })
 
 
-test_that("Function config_prep_raw_schema() @ L320", {
+test_that("Function config_prep_raw_schema() @ L330", {
   
   path <- system.file("extdata", "tool1/latest/sampleA.tool1.table1.tsv", package = "nemo")
   (x <- config_prep_raw_schema(path = path, delim = "\t"))
@@ -53,7 +53,7 @@ test_that("Function config_prep_raw_schema() @ L320", {
 })
 
 
-test_that("Function config_prep_raw() @ L365", {
+test_that("Function config_prep_raw() @ L375", {
   
   path <- system.file("extdata", "tool1/latest/sampleA.tool1.table1.tsv", package = "nemo")
   name <- "table1"

--- a/tests/testthat/test-roxytest-testexamples-cli_tidy.R
+++ b/tests/testthat/test-roxytest-testexamples-cli_tidy.R
@@ -44,7 +44,7 @@ test_that("Function cli_nemo_tidy() @ L172", {
   expect_true(length(res$written_files) > 0)
   expect_error(cli_nemo_tidy(
     workflow = "workflow1", in_dir = path, out_dir = tempfile(),
-    out_format = "badformat", id = "run1", output_id = NULL,
+    out_format = "badformat", input_id = "run1", output_id = NULL,
     dbname = NULL, dbuser = NULL, include = NULL, exclude = NULL
   ))
   expect_error(cli_nemo_tidy(


### PR DESCRIPTION
Fixes #61.

```
$ ls -l
total 104
drwxr-xr-x@ 14 pdiakumis  staff   448B  3 Jun 17:56 .
drwx------@  7 pdiakumis  staff   224B  3 Jun 17:56 ..
-rw-r--r--@  1 pdiakumis  staff   4.8K  3 Jun 17:56 metadata.parquet
-rw-r--r--@  1 pdiakumis  staff   2.7K  3 Jun 17:56 sampleA_2_tool1_table1.parquet
-rw-r--r--@  1 pdiakumis  staff   2.0K  3 Jun 17:56 sampleA_2_tool1_table2.parquet
-rw-r--r--@  1 pdiakumis  staff   2.8K  3 Jun 17:56 sampleA_2_tool1_table3.parquet
-rw-r--r--@  1 pdiakumis  staff   2.7K  3 Jun 17:56 sampleA_2_tool1_table4.parquet
-rw-r--r--@  1 pdiakumis  staff   2.4K  3 Jun 17:56 sampleA_2_tool1_table6.parquet
-rw-r--r--@  1 pdiakumis  staff   3.1K  3 Jun 17:56 sampleA_3_tool1_table1.parquet
-rw-r--r--@  1 pdiakumis  staff   2.3K  3 Jun 17:56 sampleA_tool1_table1.parquet
-rw-r--r--@  1 pdiakumis  staff   1.7K  3 Jun 17:56 sampleA_tool1_table2.parquet
-rw-r--r--@  1 pdiakumis  staff   2.0K  3 Jun 17:56 sampleA_tool1_table3.parquet
-rw-r--r--@  1 pdiakumis  staff   2.0K  3 Jun 17:56 sampleA_tool1_table4.parquet
-rw-r--r--@  1 pdiakumis  staff   2.1K  3 Jun 17:56 sampleA_tool1_table6.parquet
```

```
duckdb
DuckDB v1.5.3 (Variegata)
Enter ".help" for usage hints.
memory D SELECT * FROM "metadata.parquet";
┌──────────┬───────────┬───────────────────────────────────────────────────────────────────┬────────────────────────────────────────────┬─────────────────────────────────────────────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ input_id │ output_id │                            input_dirs                             │                 output_dir                 │                pkg_versions                 │                                                                                      files                                                                                      │
│ varchar  │  varchar  │                             varchar[]                             │                  varchar                   │ struct("name" varchar, "version" varchar)[] │                                                        struct(tbl varchar, prefix varchar, fout varchar, fin varchar)[]                                                         │
├──────────┼───────────┼───────────────────────────────────────────────────────────────────┼────────────────────────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ run1     │ NULL      │ [/Users/pdiakumis/Library/R/arm64/4.6/library/nemo/extdata/tool1] │ /Users/pdiakumis/tmp/R_TMPDIR/Rtmp6K1T9e/a │ [{'name': nemo,                             │ [{'tbl': tool1_table1, 'prefix': sampleA, 'fout': sampleA_tool1_table1.parquet, 'fin': /Users/pdiakumis/Library/R/arm64/4.6/library/nemo/extdata/tool1/v4.5.6/sampleA.tool1.tab │
│          │           │                                                                   │                                            │    'version': 0.0.3.9017                    │ le1.tsv}, {'tbl': tool1_table1, 'prefix': sampleA_2, 'fout': sampleA_2_tool1_table1.parquet, 'fin': /Users/pdiakumis/Library/R/arm64/4.6/library/nemo/extdata/tool1/v1.2.3/samp │
│          │           │                                                                   │                                            │  }                                          │ leA.tool1.table1.tsv}, {'tbl': tool1_table1, 'prefix': sampleA_3, 'fout': sampleA_3_tool1_table1.parquet, 'fin': /Users/pdiakumis/Library/R/arm64/4.6/library/nemo/extdata/tool │
│          │           │                                                                   │                                            │ ]                                           │ 1/latest/sampleA.tool1.table1.tsv}, {'tbl': tool1_table2, 'prefix': sampleA, 'fout': sampleA_tool1_table2.parquet, 'fin': /Users/pdiakumis/Library/R/arm64/4.6/library/nemo/ext │
│          │           │                                                                   │                                            │                                             │ data/tool1/v1.0.0/sampleA.tool1.table2.tsv}, {'tbl': tool1_table2, 'prefix': sampleA_2, 'fout': sampleA_2_tool1_table2.parquet, 'fin': /Users/pdiakumis/Library/R/arm64/4.6/lib │
│          │           │                                                                   │                                            │                                             │ rary/nemo/extdata/tool1/latest/sampleA.tool1.table2.tsv}, {'tbl': tool1_table3, 'prefix': sampleA, 'fout': sampleA_tool1_table3.parquet, 'fin': /Users/pdiakumis/Library/R/arm6 │
│          │           │                                                                   │                                            │                                             │ 4/4.6/library/nemo/extdata/tool1/v1.0.0/sampleA.tool1.table3.tsv}, {'tbl': tool1_table3, 'prefix': sampleA_2, 'fout': sampleA_2_tool1_table3.parquet, 'fin': /Users/pdiakumis/L │
│          │           │                                                                   │                                            │                                             │ ibrary/R/arm64/4.6/library/nemo/extdata/tool1/latest/sampleA.tool1.table3.tsv}, {'tbl': tool1_table4, 'prefix': sampleA, 'fout': sampleA_tool1_table4.parquet, 'fin': /Users/pd │
│          │           │                                                                   │                                            │                                             │ iakumis/Library/R/arm64/4.6/library/nemo/extdata/tool1/v1.0.0/sampleA.tool1.table4.tsv}, {'tbl': tool1_table4, 'prefix': sampleA_2, 'fout': sampleA_2_tool1_table4.parquet, 'fi │
│          │           │                                                                   │                                            │                                             │ n': /Users/pdiakumis/Library/R/arm64/4.6/library/nemo/extdata/tool1/latest/sampleA.tool1.table4.tsv}, {'tbl': tool1_table6, 'prefix': sampleA, 'fout': sampleA_tool1_table6.par │
│          │           │                                                                   │                                            │                                             │ quet, 'fin': /Users/pdiakumis/Library/R/arm64/4.6/library/nemo/extdata/tool1/v1.0.0/sampleA.tool1.table6.csv}, {'tbl': tool1_table6, 'prefix': sampleA_2, 'fout': sampleA_2_too │
│          │           │                                                                   │                                            │                                             │ l1_table6.parquet, 'fin': /Users/pdiakumis/Library/R/arm64/4.6/library/nemo/extdata/tool1/latest/sampleA.tool1.table6.csv}]                                                     │
└──────────┴───────────┴───────────────────────────────────────────────────────────────────┴────────────────────────────────────────────┴─────────────────────────────────────────────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```


--- And example for tidywigits:

```
SELECT * FROM "/Users/pdiakumis/projects/tidywf/tidywigits/nogit/test_data/out1/metadata.parquet";
┌──────────┬────────────────────────────┬───────────────────────────────────────────────────────────────────────────────────┬──────────────────────────────────────────────────────────────────┬────────────────────────────────────────────────────────────────────────────────────┬───────────────────────────────────────────────────────────────────────────────────┐
│ input_id │         output_id          │                                    input_dirs                                     │                            output_dir                            │                                    pkg_versions                                    │                                       files                                       │
│ varchar  │          varchar           │                                     varchar[]                                     │                             varchar                              │                    struct("name" varchar, "version" varchar)[]                     │         struct(tbl varchar, prefix varchar, fout varchar, fin varchar)[]          │
├──────────┼────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────┤
│ run123   │ 01KT69CBYC4SWEVYZK21AYCMQX │ [/Users/pdiakumis/s3/project-data-889522050439-ap-southeast-2/byob-icav2/project- │ /Users/pdiakumis/projects/tidywf/tidywigits/nogit/test_data/out1 │ [                                                                                  │ [{'tbl': alignments_dupfreq, 'prefix': L2301144, 'fout': L2301144_alignments_dupf │
│          │                            │ wgs-accreditation/analysis/oncoanalyser-wgts-dna/2025091176b237f7]                │                                                                  │  {'name': nemo, 'version': 0.0.3.9017},                                            │ req.parquet, 'fin': /Users/pdiakumis/s3/project-data-889522050439-ap-southeast-2/ │
│          │                            │                                                                                   │                                                                  │  {'name': tidywigits, 'version': 0.0.7.9003}                                       │ byob-icav2/project-wgs-accreditation/analysis/oncoanalyser-wgts-dna/2025091176b23 │
│          │                            │                                                                                   │                                                                  │ ]                                                                                  │ 7f7/L2301146__L2301144/alignments/dna/L2301144.redux.duplicate_freq.tsv}, {'tbl': │
│          │                            │                                                                                   │                                                                  │                                                                                    │  alignments_dupfreq, 'prefix': L2301146, 'fout': L2301146_alignments_dupfreq.parq │
│          │                            │                                                                                   │                                                                  │                                                                                    │ uet, 'fin': /Users/pdiakumis/s3/project-data-889522050439-ap-southeast-2/byob-ica │
│          │                            │                                                                                   │                                                                  │                                                                                    │ v2/project-wgs-accreditation/analysis/oncoanalyser-wgts-dna/2025091176b237f7/L230 │
│          │                            │                                                                                   │                                                                  │                                                                                    │ 1146__L2301144/alignments/dna/L2301146.redux.duplicate_freq.tsv}, {'tbl': amber_v │
│          │                            │                                                                                   │                                                                  │                                                                                    │ ersion, 'prefix': version, 'fout': version_amber_version.parquet, 'fin': /Users/p │
│          │                            │                                                                                   │                                                                  │                                                                                    │ diakumis/s3/project-data-889522050439-ap-southeast-2/byob-icav2/project-wgs-accre │
│          │                            │                                                                                   │                                                                  │                                                                                    │ ditation/analysis/oncoanalyser-wgts-dna/2025091176b237f7/L2301146__L2301144/amber │
│          │                            │                                                                                   │                                                                  │                                                                                    │ /amber.version}, {'tbl': amber_homozygousregion, 'prefix': L2301144, 'fout': L230 │
│          │                            │                                                                                   │                                                                  │                                                                                    │ 1144_amber_homozygousregion.parquet, 'fin': /Users/pdiakumis/s3/project-data-8895 │
│          │                            │                                                                                   │                                                                  │                                                                                    │ 22050439-ap-southeast-2/byob-icav2/project-wgs-accreditation/analysis/oncoanalyse │
│          │                            │                                                                                   │                                                                  │                                                                                    │ r-wgts-dna/2025091176b237f7/L2301146__L2301144/amber/L2301144.amber.homozygousreg │
│          │                            │                                                                                   │                                                                  │                                                                                    │ ion.tsv}, {'tbl': amber_bafpcf, 'prefix': L2301146, 'fout': L2301146_amber_bafpcf │
│          │                            │                                                                                   │                                                                  │                                                                                    │ .parquet, 'fin': /Users/pdiakumis/s3/project-data-889522050439-ap-southeast-2/byo │
│          │                            │                                                                                   │                                                                  │                                                                                    │ b-icav2/project-wgs-accreditation/analysis/oncoanalyser-wgts-dna/2025091176b237f7 │
│          │                            │                                                                                   │                                                                  │                                                                                    │ /L2301146__L2301144/amber/L2301146.amber.baf.pcf}, {'tbl': amber_qc, 'prefix': L2 │
│          │                            │                                                                                   │                                                                  │                                                                                    │ 301146, 'fout': L2301146_amber_qc.parquet, 'fin': /Users/pdiakumis/s3/project-dat │
│          │                            │                                                                                   │                                                                  │                                                                                    │ a-889522050439-ap-southeast-2/byob-icav2/project-wgs-accreditation/analysis/oncoa │
│          │                            │                                                                                   │                                                                  │                                                                                    │ nalyser-wgts-dna/2025091176b237f7/L2301146__L2301144/amber/L2301146.amber.qc}, {' │
│          │                            │                                                                                   │                                                                  │                                                                                    │ tbl': bamtools_coverage, 'prefix': L2301144, 'fout': L2301144_bamtools_coverage.p │
│          │                            │                                                                                   │                                                                  │                                                                                    │ arquet, 'fin': /Users/pdiakumis/s3/project-data-889522050439-ap-southeast-2/byob- │
│          │                            │                                                                                   │                                                                  │                                                                                    │ icav2/project-wgs-accreditation/analysis/oncoanalyser-wgts-dna/2025091176b237f7/L │
│          │                            │                                                                                   │                                                                  │                                                                                    │ 2301146__L2301144/bamtools/L2301146__L2301144_L2301144_bamtools/L2301144.bam_metr │
│          │                            │                                                                                   │                                                                  │                                                                                    │ ic.coverage.tsv}, {'tbl': bamtools_exoncvg, 'prefix': L2301144, 'fout': L2301144_ │
│          │                            │                                                                                   │                                                                  │                                                                                    │ bamtools_exoncvg.parquet, 'fin': /Users/pdiakumis/s3/project-data-889522050439-ap │
│          │                            │                                                                                   │                                                                  │                                                                                    │ -southeast-2/byob-icav2/project-wgs-accreditation/analysis/oncoanalyser-wgts-dna/ │
│          │                            │                                                                                   │                                                                  │                                                                                    │ 2025091176b237f7/L2301146__L2301144/bamtools/L2301146__L2301144_L2301144_bamtools │
│          │                            │                                                                                   │                                                                  │                                                                                    │ /L2301144.bam_metric.exon_medians.tsv}, {'tbl': bamtools_flagstats, 'prefix': L23 │
│          │                            │                                                                                   │                                                                  │                                                                                    │ 01144, 'fout': L2301144_bamtools_flagstats.parquet, 'fin': /Users/pdiakumis/s3/pr │
│          │                            │                                                                                   │                                                                  │                                                                                    │ oject-data-889522050439-ap-southeast-2/byob-icav2/project-wgs-accreditation/analy │
│          │                            │                                                                                   │                                                                  │                                                                                    │ sis/oncoanalyser-wgts-dna/2025091176b237f7/L2301146__L2301144/bamtools/L2301146__ │
│          │                            │                                                                                   │                                                                  │                                                                                    │ L2301144_L2301144_bamtools/L2301144.bam_metric.flag_counts.tsv}, {'tbl': bamtools │
│          │                            │                                                                                   │                                                                  │                                                                                    │ _fraglength, 'prefix': L2301144, 'fout': L2301144_bamtools_fraglength.parquet, '… │
└──────────┴────────────────────────────┴───────────────────────────────────────────────────────────────────────────────────┴──────────────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────────────────────────────┴───────────────────────────────────────────────────────────────────────────────────┘

```