### PR TITLE
API cleanup: rename fields and Config methods for consistency

### DIFF
--- a/R/Config.R
+++ b/R/Config.R
@@ -10,8 +10,8 @@
 #' A Config object:
 #' - belongs to a package (`pkg`);
 #' - has a tool name (`tool`);
-#' - has a parsed config list (`config`);
-#' - caches all raw schemas as a flat tibble (`raw_schemas_all`);
+#' - has a parsed tables list (`tables`);
+#' - caches all raw schemas as a flat tibble (`schemas_raw`);
 #' @examples
 #' tool <- "tool1"
 #' pkg <- "nemo"
@@ -20,12 +20,12 @@
 #' (ftypes <- conf$get_ftypes())
 #' (ftype1 <- conf$get_ftype("table1"))
 #' (descr <- conf$get_descriptions())
-#' (rs <- conf$get_schemas_all("raw"))
-#' (ts <- conf$get_schemas_all("tidy"))
-#' (s1 <- conf$get_schema("table1"))
-#' conf$get_schema("table1", v = "v1.2.3")
-#' conf$get_schema("table1", raw_or_tidy = "tidy")
-#' conf$are_schemas_valid()
+#' (rs <- conf$get_schemas_raw())
+#' (ts <- conf$get_schemas_tidy())
+#' (s1 <- conf$get_schema_raw("table1"))
+#' conf$get_schema_raw("table1", v = "v1.2.3")
+#' conf$get_schema_tidy("table1")
+#' conf$validate_schemas()
 #' (cm <- conf$get_col_map("table5"))
 #'
 #' @testexamples
@@ -39,17 +39,17 @@
 #' expect_equal(ftype1, "txt")
 #' # get_descriptions
 #' expect_equal(nrow(descr), 6)
-#' # get_schemas_all
+#' # get_schemas_raw / get_schemas_tidy
 #' expect_equal(dplyr::filter(rs, .data$name == "table1") |> nrow(), 3)
 #' expect_equal(dplyr::filter(ts, .data$name == "table1") |> nrow(), 3)
-#' # get_schema
+#' # get_schema_raw
 #' expect_named(s1, c("version", "field", "type"))
-#' expect_equal(nrow(conf$get_schema("table1", v = "v1.2.3")), 5)
-#' expect_equal(nrow(conf$get_schema("table1", v = "v4.5.6")), 4)
-#' expect_error(conf$get_schema("foo"))
-#' expect_error(conf$get_schema("table1", v = "foo"))
-#' # are_schemas_valid
-#' expect_true(conf$are_schemas_valid())
+#' expect_equal(nrow(conf$get_schema_raw("table1", v = "v1.2.3")), 5)
+#' expect_equal(nrow(conf$get_schema_raw("table1", v = "v4.5.6")), 4)
+#' expect_error(conf$get_schema_raw("foo"))
+#' expect_error(conf$get_schema_raw("table1", v = "foo"))
+#' # validate_schemas
+#' expect_true(conf$validate_schemas())
 #' # get_col_map
 #' expect_named(cm, c("raw", "tidy", "type", "description"))
 #'
@@ -63,12 +63,12 @@ Config <- R6::R6Class(
     #' @field pkg (`character(1)`)\cr
     #' Package name tool belongs to (for config lookup).
     pkg = NULL,
-    #' @field config (`list()`)\cr
-    #' Config list (parsed schema.yaml).
-    config = NULL,
-    #' @field raw_schemas_all (`tibble()`)\cr
+    #' @field tables (`list()`)\cr
+    #' Tables list (parsed from schema.yaml).
+    tables = NULL,
+    #' @field schemas_raw (`tibble()`)\cr
     #' All raw schemas for tool (versioned, for schema_guess).
-    raw_schemas_all = NULL,
+    schemas_raw = NULL,
 
     #' @description Create a new Config object.
     #' @param tool (`character(1)`)\cr
@@ -81,8 +81,8 @@ Config <- R6::R6Class(
       tool <- tolower(tool)
       self$tool <- tool
       self$pkg <- pkg
-      self$config <- self$read()
-      self$raw_schemas_all <- self$get_schemas_all("raw")
+      self$tables <- self$read()[["tables"]]
+      self$schemas_raw <- self$get_schemas_raw()
     },
     #' @description Print details about the Config.
     #' @param ... (ignored).
@@ -90,10 +90,10 @@ Config <- R6::R6Class(
     #' R6 object invisibly.
     print = function(...) {
       res <- tibble::tribble(
-        ~var   , ~value                                   ,
-        "tool" , self$tool                                ,
-        "pkg"  , self$pkg                                 ,
-        "nraw" , as.character(nrow(self$raw_schemas_all))
+        ~var   , ~value                               ,
+        "tool" , self$tool                            ,
+        "pkg"  , self$pkg                             ,
+        "nraw" , as.character(nrow(self$schemas_raw))
       )
       cat(glue("#--- Config {self$pkg}::{self$tool} ---#\n"))
       print(knitr::kable(res))
@@ -123,7 +123,7 @@ Config <- R6::R6Class(
     #' @return (`tibble()`)\cr
     #' Table `name` and its `pattern`.
     get_patterns = function() {
-      self$config[["tables"]] |>
+      self$tables |>
         purrr::map("pattern") |>
         tibble::enframe(value = "pattern") |>
         tidyr::unnest("pattern")
@@ -132,7 +132,7 @@ Config <- R6::R6Class(
     #' @return (`tibble()`)\cr
     #' Table `name` and its `ftype`.
     get_ftypes = function() {
-      self$config[["tables"]] |>
+      self$tables |>
         purrr::map("ftype") |>
         tibble::enframe(value = "ftype") |>
         tidyr::unnest("ftype")
@@ -143,103 +143,69 @@ Config <- R6::R6Class(
     #' @return (`character(1)`)\cr
     #' File type.
     get_ftype = function(x) {
-      tabs <- self$config[["tables"]]
       assertthat::assert_that(
-        x %in% names(tabs),
+        x %in% names(self$tables),
         msg = glue("{x} not found in tables for {self$tool}.")
       )
-      tabs[[x]][["ftype"]]
+      self$tables[[x]][["ftype"]]
     },
     #' @description Return all table descriptions.
     #' @return (`tibble()`)\cr
     #' Table `name` and its `description`.
     get_descriptions = function() {
-      self$config[["tables"]] |>
+      self$tables |>
         purrr::map("description") |>
         tibble::enframe(value = "description") |>
         tidyr::unnest("description")
     },
-    #' @description Return all raw or tidy schemas.
-    #' @param raw_or_tidy (`character(1)`)\cr
-    #' Either the raw or the tidy schema, or both.
+    #' @description Return raw schemas for all tables.
     #' @return (`tibble()`)\cr
     #' Table `name`, `tbl_description`, `version`, and `schema`
-    #' (list-col of tibble(field, type) for `"raw"`/`"tidy"`, or tibble(raw, tidy, type) for `"both"`).
-    get_schemas_all = function(raw_or_tidy = "raw") {
-      rt <- c("raw", "tidy", "both")
-      rt_col <- glue::glue_collapse(rt, sep = ", ", last = " or ")
-      assertthat::assert_that(
-        raw_or_tidy %in% rt,
-        msg = glue("raw_or_tidy must be one of {rt_col}, got '{raw_or_tidy}'.")
-      )
-      tabs <- self$config[["tables"]]
-      .get_schema <- function(tab, tab_name) {
-        cols_df <- tab[["columns"]] |>
-          purrr::map(\(col) {
-            col[["versions"]] <- list(col[["versions"]])
-            tibble::as_tibble_row(col)
-          }) |>
-          dplyr::bind_rows()
-        description <- tibble::tibble(tbl_description = tab[["description"]])
-        versions <- config_sort_versions(unique(unlist(cols_df[["versions"]])))
-        .get_schema_per_version <- function(v) {
-          cols_filtered <- cols_df |>
-            dplyr::filter(purrr::map_lgl(.data$versions, \(vs) v %in% vs)) |>
-            dplyr::mutate(type = schema_type_remap(.data$type))
-          cols_v <- if (raw_or_tidy == "both") {
-            cols_filtered |> dplyr::select("raw", "tidy", "type")
-          } else {
-            cols_filtered |> dplyr::select(field = dplyr::all_of({{ raw_or_tidy }}), "type")
-          }
-          tibble::tibble(version = v, schema = list(cols_v))
-        }
-        schema_rows <- purrr::map(versions, \(v) .get_schema_per_version(v)) |>
-          dplyr::bind_rows()
-        dplyr::bind_cols(description, schema_rows) |>
-          dplyr::mutate(name = tab_name, .before = 1)
-      }
-      tabs |>
-        purrr::imap(\(tab, tab_name) .get_schema(tab, tab_name)) |>
-        dplyr::bind_rows()
+    #' (list-col of tibble(field, type)).
+    get_schemas_raw = function() {
+      private$get_schemas("raw")
+    },
+    #' @description Return tidy schemas for all tables.
+    #' @return (`tibble()`)\cr
+    #' Table `name`, `tbl_description`, `version`, and `schema`
+    #' (list-col of tibble(field, type)).
+    get_schemas_tidy = function() {
+      private$get_schemas("tidy")
+    },
+    #' @description Return both raw and tidy schemas for all tables.
+    #' @return (`tibble()`)\cr
+    #' Table `name`, `tbl_description`, `version`, and `schema`
+    #' (list-col of tibble(raw, tidy, type)).
+    get_schemas_both = function() {
+      private$get_schemas("both")
     },
     #' @description Get raw schema for a specific table and optional version.
     #' @param x (`character(1)`)\cr
     #' Table name.
     #' @param v (`character(1)`)\cr
     #' Version. If NULL, returns all versions.
-    #' @param raw_or_tidy (`character(1)`)\cr
-    #' Either the raw or the tidy schema.
     #' @return (`tibble()`)\cr
     #' Table `version`, `field` and `type`.
-    get_schema = function(x = NULL, v = NULL, raw_or_tidy = "raw") {
-      stopifnot(!is.null(x))
-      s <- self$get_schemas_all(raw_or_tidy = raw_or_tidy)
-      assertthat::assert_that(
-        x %in% s[["name"]],
-        msg = glue("{x} not found in schemas for {self$tool}.")
-      )
-      res <- s |>
-        dplyr::filter(.data$name == x)
-      if (!is.null(v)) {
-        assertthat::assert_that(
-          v %in% res[["version"]],
-          msg = glue("{v} not found in versions for {x} in {self$tool}.")
-        )
-        res <- res |>
-          dplyr::filter(.data$version == v)
-      }
-      res |>
-        tidyr::unnest("schema") |>
-        dplyr::select("version", "field", "type")
+    get_schema_raw = function(x = NULL, v = NULL) {
+      private$get_schema(x, v, self$schemas_raw)
+    },
+    #' @description Get tidy schema for a specific table and optional version.
+    #' @param x (`character(1)`)\cr
+    #' Table name.
+    #' @param v (`character(1)`)\cr
+    #' Version. If NULL, returns all versions.
+    #' @return (`tibble()`)\cr
+    #' Table `version`, `field` and `type`.
+    get_schema_tidy = function(x = NULL, v = NULL) {
+      private$get_schema(x, v, self$get_schemas_tidy())
     },
     #' @description Validate schemas.
     #' @return (`logical(1)`)\cr
     #' TRUE or FALSE.
-    are_schemas_valid = function() {
+    validate_schemas = function() {
       valid_types <- c(char = "c", int = "i", float = "d")
       valid_types_print <- glue::glue_collapse(valid_types, sep = ", ", last = " or ")
-      s <- self$raw_schemas_all
-      invalid <- s |>
+      invalid <- self$schemas_raw |>
         tidyr::unnest("schema") |>
         dplyr::mutate(invalid_type = !.data$type %in% valid_types) |>
         dplyr::filter(.data$invalid_type) |>
@@ -252,11 +218,10 @@ Config <- R6::R6Class(
         msg1 <- invalid |>
           dplyr::pull("warn") |>
           glue::glue_collapse(sep = "; ")
-        msg2 <- glue(
+        warning(glue(
           "Field types need to be one of: {valid_types_print}\n",
           "Check the following in the {self$tool} config:\n{msg1}"
-        )
-        warning(msg2)
+        ))
         return(FALSE)
       }
       return(TRUE)
@@ -269,12 +234,11 @@ Config <- R6::R6Class(
     #' Version. If NULL, uses the latest version.
     get_col_map = function(x = NULL, v = NULL) {
       stopifnot(!is.null(x))
-      tabs <- self$config[["tables"]]
       assertthat::assert_that(
-        x %in% names(tabs),
+        x %in% names(self$tables),
         msg = glue("{x} not found in tables for {self$tool}.")
       )
-      cols_df <- tabs[[x]][["columns"]] |>
+      cols_df <- self$tables[[x]][["columns"]] |>
         purrr::map(\(col) {
           col[["versions"]] <- list(col[["versions"]])
           tibble::as_tibble_row(col)
@@ -294,7 +258,59 @@ Config <- R6::R6Class(
         dplyr::mutate(type = schema_type_remap(.data$type)) |>
         dplyr::select("raw", "tidy", "type", "description")
     }
-  ) # end public
+  ), # end public
+  private = list(
+    get_schemas = function(raw_or_tidy) {
+      .get_one <- function(tab, tab_name) {
+        cols_df <- tab[["columns"]] |>
+          purrr::map(\(col) {
+            col[["versions"]] <- list(col[["versions"]])
+            tibble::as_tibble_row(col)
+          }) |>
+          dplyr::bind_rows()
+        description <- tibble::tibble(tbl_description = tab[["description"]])
+        versions <- config_sort_versions(unique(unlist(cols_df[["versions"]])))
+        .get_version <- function(v) {
+          cols_filtered <- cols_df |>
+            dplyr::filter(purrr::map_lgl(.data$versions, \(vs) v %in% vs)) |>
+            dplyr::mutate(type = schema_type_remap(.data$type))
+          cols_v <- if (raw_or_tidy == "both") {
+            cols_filtered |> dplyr::select("raw", "tidy", "type")
+          } else {
+            cols_filtered |> dplyr::select(field = dplyr::all_of({{ raw_or_tidy }}), "type")
+          }
+          tibble::tibble(version = v, schema = list(cols_v))
+        }
+        schema_rows <- purrr::map(versions, .get_version) |>
+          dplyr::bind_rows()
+        dplyr::bind_cols(description, schema_rows) |>
+          dplyr::mutate(name = tab_name, .before = 1)
+      }
+      self$tables |>
+        purrr::imap(.get_one) |>
+        dplyr::bind_rows()
+    },
+    get_schema = function(x, v, schemas) {
+      stopifnot(!is.null(x))
+      assertthat::assert_that(
+        x %in% schemas[["name"]],
+        msg = glue("{x} not found in schemas for {self$tool}.")
+      )
+      res <- schemas |>
+        dplyr::filter(.data$name == x)
+      if (!is.null(v)) {
+        assertthat::assert_that(
+          v %in% res[["version"]],
+          msg = glue("{v} not found in versions for {x} in {self$tool}.")
+        )
+        res <- res |>
+          dplyr::filter(.data$version == v)
+      }
+      res |>
+        tidyr::unnest("schema") |>
+        dplyr::select("version", "field", "type")
+    }
+  ) # end private
 )
 
 #' Sort version strings with "latest" always last

--- a/R/Config.R
+++ b/R/Config.R
@@ -277,7 +277,7 @@ Config <- R6::R6Class(
           cols_v <- if (raw_or_tidy == "both") {
             cols_filtered |> dplyr::select("raw", "tidy", "type")
           } else {
-            cols_filtered |> dplyr::select(field = dplyr::all_of({{ raw_or_tidy }}), "type")
+            cols_filtered |> dplyr::select(field = dplyr::all_of(raw_or_tidy), "type")
           }
           tibble::tibble(version = v, schema = list(cols_v))
         }

--- a/R/Tool.R
+++ b/R/Tool.R
@@ -119,18 +119,18 @@ Tool <- R6::R6Class(
     #' @field tbls (`tibble()`)\cr
     #' Tibble of tidy tibbles.
     tbls = NULL,
-    #' @field raw_schemas_all (`tibble()`)\cr
+    #' @field schemas_raw (`tibble()`)\cr
     #' All raw schemas for tool.
-    raw_schemas_all = NULL,
-    #' @field tidy_schemas_all (`tibble()`)\cr
+    schemas_raw = NULL,
+    #' @field schemas_tidy (`tibble()`)\cr
     #' All tidy schemas for tool.
-    tidy_schemas_all = NULL,
-    #' @field get_tidy_schema (`function()`)\cr
+    schemas_tidy = NULL,
+    #' @field get_schema_tidy (`function()`)\cr
     #' Get specific tidy schema.
-    get_tidy_schema = NULL,
-    #' @field get_raw_schema (`function()`)\cr
+    get_schema_tidy = NULL,
+    #' @field get_schema_raw (`function()`)\cr
     #' Get specific raw schema.
-    get_raw_schema = NULL,
+    get_schema_raw = NULL,
     #' @field get_col_map (`function()`)\cr
     #' Get column mapping (raw -> tidy) for a table.
     get_col_map = NULL,
@@ -167,13 +167,13 @@ Tool <- R6::R6Class(
       self$pkg <- pkg
       self$path <- path
       self$config <- Config$new(self$name, pkg = self$pkg)
-      self$raw_schemas_all <- self$config$raw_schemas_all
-      self$tidy_schemas_all <- self$config$get_schemas_all("tidy")
-      self$get_tidy_schema <- function(x = NULL, v = NULL) {
-        self$config$get_schema(x = x, v = v, raw_or_tidy = "tidy")
+      self$schemas_raw <- self$config$schemas_raw
+      self$schemas_tidy <- self$config$get_schemas_tidy()
+      self$get_schema_tidy <- function(x = NULL, v = NULL) {
+        self$config$get_schema_tidy(x = x, v = v)
       }
-      self$get_raw_schema <- function(x = NULL, v = NULL) {
-        self$config$get_schema(x = x, v = v, raw_or_tidy = "raw")
+      self$get_schema_raw <- function(x = NULL, v = NULL) {
+        self$config$get_schema_raw(x = x, v = v)
       }
       self$get_col_map <- self$config$get_col_map
       self$files_tbl <- files_tbl
@@ -367,7 +367,7 @@ Tool <- R6::R6Class(
       parse_file(
         fpath = x,
         pname = name,
-        schemas_all = self$raw_schemas_all,
+        schemas_all = self$schemas_raw,
         delim = delim,
         ...
       )
@@ -387,7 +387,7 @@ Tool <- R6::R6Class(
       }
       version <- get_tbl_version_attr(x)
       stopifnot(!is.null(version))
-      schema <- self$get_tidy_schema(name, v = version)
+      schema <- self$get_schema_tidy(name, v = version)
       colnames(x) <- schema[["field"]]
       if (convert_types) {
         ctypes <- schema |>
@@ -417,7 +417,7 @@ Tool <- R6::R6Class(
       parse_file_keyvalue(
         fpath = x,
         pname = name,
-        schemas_all = self$raw_schemas_all,
+        schemas_all = self$schemas_raw,
         delim = delim,
         ...
       )
@@ -434,7 +434,7 @@ Tool <- R6::R6Class(
     #' Parsed data in tibble.
     .parse_file_nohead = function(x, pname, delim = "\t", ...) {
       ncols <- file_hdr(x, delim = delim, ...) |> length()
-      schema <- self$raw_schemas_all |>
+      schema <- self$schemas_raw |>
         dplyr::filter(.data$name == pname) |>
         dplyr::select("version", "schema") |>
         dplyr::rowwise() |>

--- a/R/Workflow.R
+++ b/R/Workflow.R
@@ -25,7 +25,7 @@
 #' wf$filter_files(exclude = "tool1_table5")
 #' wf$tidy()
 #' (tbls <- wf$get_tbls())
-#' (rs <- wf$get_raw_schemas_all())
+#' (rs <- wf$get_schemas_raw())
 #' dir1 <- fs::file_temp(); dir2 <- fs::file_temp()
 #' wf$write(output_dir = dir1, format = "parquet", input_id = "run1")
 #' (lf1 <- list.files(dir1, pattern = "tool1.*parquet", full.names = TRUE))
@@ -45,7 +45,7 @@
 #' expect_false("tool1_table5" %in% tbls$tool_parser)
 #' expect_true("tool1_table4" %in% tbls$tool_parser)
 #' expect_named(tbls, c(nms1, "tidy"))
-#' # get_raw_schemas_all
+#' # get_schemas_raw
 #' expect_named(rs, c("tool", "name", "tbl_description", "version", "schema"))
 #' # write: two table4 output files (one per version)
 #' expect_equal(sum(grepl("table4", basename(lf1))), 2)
@@ -256,11 +256,11 @@ Workflow <- R6::R6Class(
     },
     #' @description Get raw schemas for all Tools.
     #' @return (`tibble()`)\cr
-    #' Bound `raw_schemas_all` tibbles from all Tools, with a leading `tool` column.
-    get_raw_schemas_all = function() {
+    #' Bound `schemas_raw` tibbles from all Tools, with a leading `tool` column.
+    get_schemas_raw = function() {
       self$tools |>
         purrr::map(\(x) {
-          x$raw_schemas_all |>
+          x$schemas_raw |>
             dplyr::mutate(tool = x$name) |>
             dplyr::relocate("tool", .before = 1)
         }) |>
@@ -268,11 +268,11 @@ Workflow <- R6::R6Class(
     },
     #' @description Get tidy schemas for all Tools.
     #' @return (`tibble()`)\cr
-    #' Bound tidy schema tibbles from all Tools, with a leading `tool` column.
-    get_tidy_schemas_all = function() {
+    #' Bound `schemas_tidy` tibbles from all Tools, with a leading `tool` column.
+    get_schemas_tidy = function() {
       self$tools |>
         purrr::map(\(x) {
-          x$tidy_schemas_all |>
+          x$schemas_tidy |>
             dplyr::mutate(tool = x$name) |>
             dplyr::relocate("tool", .before = 1)
         }) |>

--- a/R/parse.R
+++ b/R/parse.R
@@ -16,7 +16,7 @@
 #' @examples
 #' path <- system.file("extdata/tool1", package = "nemo")
 #' x <- Tool$new("tool1", pkg = "nemo", path)
-#' schemas_all <- x$raw_schemas_all
+#' schemas_all <- x$schemas_raw
 #' f <- function(ver, tbl) file.path(path, ver, paste0("sampleA.tool1.", tbl, ".tsv"))
 #' # table1: three versions with different column sets
 #' (d1_v123 <- parse_file(f("v1.2.3", "table1"), "table1", schemas_all))
@@ -76,7 +76,7 @@ parse_file <- function(fpath, pname, schemas_all, delim = "\t", ...) {
 #' @examples
 #' path <- system.file("extdata/tool1", package = "nemo")
 #' x <- Tool$new("tool1", pkg = "nemo", path)
-#' schemas_all <- x$raw_schemas_all
+#' schemas_all <- x$schemas_raw
 #' pname <- "table4"
 #' fpath_latest <- file.path(path, "latest", "sampleA.tool1.table4.tsv")
 #' fpath_v1 <- file.path(path, "v1.0.0", "sampleA.tool1.table4.tsv")
@@ -174,7 +174,7 @@ file_hdr <- function(fpath, delim = "\t", n_max = 0, ...) {
 #' cnames1 <- file_hdr(fpath1)
 #' cnames2 <- file_hdr(fpath2)
 #' conf <- Config$new("tool1", pkg = "nemo")
-#' schemas_all <- conf$get_schemas_all("raw")
+#' schemas_all <- conf$get_schemas_raw()
 #' (s1 <- schema_guess(pname, cnames1, schemas_all))
 #' (s2 <- schema_guess(pname, cnames2, schemas_all))
 #'
@@ -231,7 +231,7 @@ schema_guess <- function(pname, cnames, schemas_all) {
 #' @examples
 #' path <- system.file("extdata/tool1", package = "nemo")
 #' x <- Tool1$new(path)
-#' schemas_all <- x$raw_schemas_all
+#' schemas_all <- x$schemas_raw
 #' pname <- "table3"
 #' f <- function(ver) file.path(path, ver, "sampleA.tool1.table3.tsv")
 #' # v1.0.0: 3 key-value pairs (SampleID, QCStatus, TotalReads)

--- a/R/schema_vis.R
+++ b/R/schema_vis.R
@@ -196,7 +196,7 @@ reactable_schema <- function(dat, ...) {
 nemo_schemavis_data <- function(tools, pkg = "nemo") {
   get_one <- function(tool) {
     conf <- Config$new(tool, pkg = pkg)
-    conf$get_schemas_all("both") |>
+    conf$get_schemas_both() |>
       dplyr::select(tbl = "name", description = "tbl_description", "version", "schema") |>
       tidyr::nest(schema_version = c("version", "schema")) |>
       dplyr::mutate(tool = toupper(tool))

--- a/man/Config.Rd
+++ b/man/Config.Rd
@@ -14,8 +14,8 @@ A Config object:
 \itemize{
 \item belongs to a package (\code{pkg});
 \item has a tool name (\code{tool});
-\item has a parsed config list (\code{config});
-\item caches all raw schemas as a flat tibble (\code{raw_schemas_all});
+\item has a parsed tables list (\code{tables});
+\item caches all raw schemas as a flat tibble (\code{schemas_raw});
 }
 }
 \examples{
@@ -26,12 +26,12 @@ conf <- Config$new(tool, pkg)
 (ftypes <- conf$get_ftypes())
 (ftype1 <- conf$get_ftype("table1"))
 (descr <- conf$get_descriptions())
-(rs <- conf$get_schemas_all("raw"))
-(ts <- conf$get_schemas_all("tidy"))
-(s1 <- conf$get_schema("table1"))
-conf$get_schema("table1", v = "v1.2.3")
-conf$get_schema("table1", raw_or_tidy = "tidy")
-conf$are_schemas_valid()
+(rs <- conf$get_schemas_raw())
+(ts <- conf$get_schemas_tidy())
+(s1 <- conf$get_schema_raw("table1"))
+conf$get_schema_raw("table1", v = "v1.2.3")
+conf$get_schema_tidy("table1")
+conf$validate_schemas()
 (cm <- conf$get_col_map("table5"))
 
 }
@@ -44,10 +44,10 @@ Tool name.}
 \item{\code{pkg}}{(\code{character(1)})\cr
 Package name tool belongs to (for config lookup).}
 
-\item{\code{config}}{(\code{list()})\cr
-Config list (parsed schema.yaml).}
+\item{\code{tables}}{(\code{list()})\cr
+Tables list (parsed from schema.yaml).}
 
-\item{\code{raw_schemas_all}}{(\code{tibble()})\cr
+\item{\code{schemas_raw}}{(\code{tibble()})\cr
 All raw schemas for tool (versioned, for schema_guess).}
 }
 \if{html}{\out{</div>}}
@@ -62,9 +62,12 @@ All raw schemas for tool (versioned, for schema_guess).}
 \item \href{#method-Config-get_ftypes}{\code{Config$get_ftypes()}}
 \item \href{#method-Config-get_ftype}{\code{Config$get_ftype()}}
 \item \href{#method-Config-get_descriptions}{\code{Config$get_descriptions()}}
-\item \href{#method-Config-get_schemas_all}{\code{Config$get_schemas_all()}}
-\item \href{#method-Config-get_schema}{\code{Config$get_schema()}}
-\item \href{#method-Config-are_schemas_valid}{\code{Config$are_schemas_valid()}}
+\item \href{#method-Config-get_schemas_raw}{\code{Config$get_schemas_raw()}}
+\item \href{#method-Config-get_schemas_tidy}{\code{Config$get_schemas_tidy()}}
+\item \href{#method-Config-get_schemas_both}{\code{Config$get_schemas_both()}}
+\item \href{#method-Config-get_schema_raw}{\code{Config$get_schema_raw()}}
+\item \href{#method-Config-get_schema_tidy}{\code{Config$get_schema_tidy()}}
+\item \href{#method-Config-validate_schemas}{\code{Config$validate_schemas()}}
 \item \href{#method-Config-get_col_map}{\code{Config$get_col_map()}}
 \item \href{#method-Config-clone}{\code{Config$clone()}}
 }
@@ -194,35 +197,57 @@ Table \code{name} and its \code{description}.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Config-get_schemas_all"></a>}}
-\if{latex}{\out{\hypertarget{method-Config-get_schemas_all}{}}}
-\subsection{Method \code{get_schemas_all()}}{
-Return all raw or tidy schemas.
+\if{html}{\out{<a id="method-Config-get_schemas_raw"></a>}}
+\if{latex}{\out{\hypertarget{method-Config-get_schemas_raw}{}}}
+\subsection{Method \code{get_schemas_raw()}}{
+Return raw schemas for all tables.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Config$get_schemas_all(raw_or_tidy = "raw")}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Config$get_schemas_raw()}\if{html}{\out{</div>}}
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{raw_or_tidy}}{(\code{character(1)})\cr
-Either the raw or the tidy schema, or both.}
-}
-\if{html}{\out{</div>}}
-}
 \subsection{Returns}{
 (\code{tibble()})\cr
 Table \code{name}, \code{tbl_description}, \code{version}, and \code{schema}
-(list-col of tibble(field, type) for \code{"raw"}/\code{"tidy"}, or tibble(raw, tidy, type) for \code{"both"}).
+(list-col of tibble(field, type)).
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Config-get_schema"></a>}}
-\if{latex}{\out{\hypertarget{method-Config-get_schema}{}}}
-\subsection{Method \code{get_schema()}}{
+\if{html}{\out{<a id="method-Config-get_schemas_tidy"></a>}}
+\if{latex}{\out{\hypertarget{method-Config-get_schemas_tidy}{}}}
+\subsection{Method \code{get_schemas_tidy()}}{
+Return tidy schemas for all tables.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Config$get_schemas_tidy()}\if{html}{\out{</div>}}
+}
+
+\subsection{Returns}{
+(\code{tibble()})\cr
+Table \code{name}, \code{tbl_description}, \code{version}, and \code{schema}
+(list-col of tibble(field, type)).
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Config-get_schemas_both"></a>}}
+\if{latex}{\out{\hypertarget{method-Config-get_schemas_both}{}}}
+\subsection{Method \code{get_schemas_both()}}{
+Return both raw and tidy schemas for all tables.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Config$get_schemas_both()}\if{html}{\out{</div>}}
+}
+
+\subsection{Returns}{
+(\code{tibble()})\cr
+Table \code{name}, \code{tbl_description}, \code{version}, and \code{schema}
+(list-col of tibble(raw, tidy, type)).
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Config-get_schema_raw"></a>}}
+\if{latex}{\out{\hypertarget{method-Config-get_schema_raw}{}}}
+\subsection{Method \code{get_schema_raw()}}{
 Get raw schema for a specific table and optional version.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Config$get_schema(x = NULL, v = NULL, raw_or_tidy = "raw")}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Config$get_schema_raw(x = NULL, v = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -233,9 +258,6 @@ Table name.}
 
 \item{\code{v}}{(\code{character(1)})\cr
 Version. If NULL, returns all versions.}
-
-\item{\code{raw_or_tidy}}{(\code{character(1)})\cr
-Either the raw or the tidy schema.}
 }
 \if{html}{\out{</div>}}
 }
@@ -245,12 +267,37 @@ Table \code{version}, \code{field} and \code{type}.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Config-are_schemas_valid"></a>}}
-\if{latex}{\out{\hypertarget{method-Config-are_schemas_valid}{}}}
-\subsection{Method \code{are_schemas_valid()}}{
+\if{html}{\out{<a id="method-Config-get_schema_tidy"></a>}}
+\if{latex}{\out{\hypertarget{method-Config-get_schema_tidy}{}}}
+\subsection{Method \code{get_schema_tidy()}}{
+Get tidy schema for a specific table and optional version.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Config$get_schema_tidy(x = NULL, v = NULL)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{x}}{(\code{character(1)})\cr
+Table name.}
+
+\item{\code{v}}{(\code{character(1)})\cr
+Version. If NULL, returns all versions.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+(\code{tibble()})\cr
+Table \code{version}, \code{field} and \code{type}.
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Config-validate_schemas"></a>}}
+\if{latex}{\out{\hypertarget{method-Config-validate_schemas}{}}}
+\subsection{Method \code{validate_schemas()}}{
 Validate schemas.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Config$are_schemas_valid()}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Config$validate_schemas()}\if{html}{\out{</div>}}
 }
 
 \subsection{Returns}{

--- a/man/Tool.Rd
+++ b/man/Tool.Rd
@@ -74,16 +74,16 @@ Tibble of files matching available Tool patterns.}
 \item{\code{tbls}}{(\code{tibble()})\cr
 Tibble of tidy tibbles.}
 
-\item{\code{raw_schemas_all}}{(\code{tibble()})\cr
+\item{\code{schemas_raw}}{(\code{tibble()})\cr
 All raw schemas for tool.}
 
-\item{\code{tidy_schemas_all}}{(\code{tibble()})\cr
+\item{\code{schemas_tidy}}{(\code{tibble()})\cr
 All tidy schemas for tool.}
 
-\item{\code{get_tidy_schema}}{(\verb{function()})\cr
+\item{\code{get_schema_tidy}}{(\verb{function()})\cr
 Get specific tidy schema.}
 
-\item{\code{get_raw_schema}}{(\verb{function()})\cr
+\item{\code{get_schema_raw}}{(\verb{function()})\cr
 Get specific raw schema.}
 
 \item{\code{get_col_map}}{(\verb{function()})\cr

--- a/man/Workflow.Rd
+++ b/man/Workflow.Rd
@@ -30,7 +30,7 @@ wf <- Workflow$new(name = "wf1", path = path, tools = tools)
 wf$filter_files(exclude = "tool1_table5")
 wf$tidy()
 (tbls <- wf$get_tbls())
-(rs <- wf$get_raw_schemas_all())
+(rs <- wf$get_schemas_raw())
 dir1 <- fs::file_temp(); dir2 <- fs::file_temp()
 wf$write(output_dir = dir1, format = "parquet", input_id = "run1")
 (lf1 <- list.files(dir1, pattern = "tool1.*parquet", full.names = TRUE))
@@ -72,8 +72,8 @@ Tibble of files written from \code{self$write()}.}
 \item \href{#method-Workflow-tidy}{\code{Workflow$tidy()}}
 \item \href{#method-Workflow-write}{\code{Workflow$write()}}
 \item \href{#method-Workflow-wrangle}{\code{Workflow$wrangle()}}
-\item \href{#method-Workflow-get_raw_schemas_all}{\code{Workflow$get_raw_schemas_all()}}
-\item \href{#method-Workflow-get_tidy_schemas_all}{\code{Workflow$get_tidy_schemas_all()}}
+\item \href{#method-Workflow-get_schemas_raw}{\code{Workflow$get_schemas_raw()}}
+\item \href{#method-Workflow-get_schemas_tidy}{\code{Workflow$get_schemas_tidy()}}
 \item \href{#method-Workflow-get_tbls}{\code{Workflow$get_tbls()}}
 \item \href{#method-Workflow-get_metadata}{\code{Workflow$get_metadata()}}
 \item \href{#method-Workflow-clone}{\code{Workflow$clone()}}
@@ -303,31 +303,31 @@ R6 object invisibly.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Workflow-get_raw_schemas_all"></a>}}
-\if{latex}{\out{\hypertarget{method-Workflow-get_raw_schemas_all}{}}}
-\subsection{Method \code{get_raw_schemas_all()}}{
+\if{html}{\out{<a id="method-Workflow-get_schemas_raw"></a>}}
+\if{latex}{\out{\hypertarget{method-Workflow-get_schemas_raw}{}}}
+\subsection{Method \code{get_schemas_raw()}}{
 Get raw schemas for all Tools.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Workflow$get_raw_schemas_all()}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Workflow$get_schemas_raw()}\if{html}{\out{</div>}}
 }
 
 \subsection{Returns}{
 (\code{tibble()})\cr
-Bound \code{raw_schemas_all} tibbles from all Tools, with a leading \code{tool} column.
+Bound \code{schemas_raw} tibbles from all Tools, with a leading \code{tool} column.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Workflow-get_tidy_schemas_all"></a>}}
-\if{latex}{\out{\hypertarget{method-Workflow-get_tidy_schemas_all}{}}}
-\subsection{Method \code{get_tidy_schemas_all()}}{
+\if{html}{\out{<a id="method-Workflow-get_schemas_tidy"></a>}}
+\if{latex}{\out{\hypertarget{method-Workflow-get_schemas_tidy}{}}}
+\subsection{Method \code{get_schemas_tidy()}}{
 Get tidy schemas for all Tools.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Workflow$get_tidy_schemas_all()}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Workflow$get_schemas_tidy()}\if{html}{\out{</div>}}
 }
 
 \subsection{Returns}{
 (\code{tibble()})\cr
-Bound tidy schema tibbles from all Tools, with a leading \code{tool} column.
+Bound \code{schemas_tidy} tibbles from all Tools, with a leading \code{tool} column.
 }
 }
 \if{html}{\out{<hr>}}

--- a/man/Workflow1.Rd
+++ b/man/Workflow1.Rd
@@ -29,9 +29,9 @@ wf$wrangle(output_dir = dir1, format = "parquet", input_id = "run1")
 <ul>
 <li><span class="pkg-link" data-pkg="nemo" data-topic="Workflow" data-id="filter_files"><a href='../../nemo/html/Workflow.html#method-Workflow-filter_files'><code>nemo::Workflow$filter_files()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="nemo" data-topic="Workflow" data-id="get_metadata"><a href='../../nemo/html/Workflow.html#method-Workflow-get_metadata'><code>nemo::Workflow$get_metadata()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="nemo" data-topic="Workflow" data-id="get_raw_schemas_all"><a href='../../nemo/html/Workflow.html#method-Workflow-get_raw_schemas_all'><code>nemo::Workflow$get_raw_schemas_all()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="nemo" data-topic="Workflow" data-id="get_schemas_raw"><a href='../../nemo/html/Workflow.html#method-Workflow-get_schemas_raw'><code>nemo::Workflow$get_schemas_raw()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="nemo" data-topic="Workflow" data-id="get_schemas_tidy"><a href='../../nemo/html/Workflow.html#method-Workflow-get_schemas_tidy'><code>nemo::Workflow$get_schemas_tidy()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="nemo" data-topic="Workflow" data-id="get_tbls"><a href='../../nemo/html/Workflow.html#method-Workflow-get_tbls'><code>nemo::Workflow$get_tbls()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="nemo" data-topic="Workflow" data-id="get_tidy_schemas_all"><a href='../../nemo/html/Workflow.html#method-Workflow-get_tidy_schemas_all'><code>nemo::Workflow$get_tidy_schemas_all()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="nemo" data-topic="Workflow" data-id="list_files"><a href='../../nemo/html/Workflow.html#method-Workflow-list_files'><code>nemo::Workflow$list_files()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="nemo" data-topic="Workflow" data-id="print"><a href='../../nemo/html/Workflow.html#method-Workflow-print'><code>nemo::Workflow$print()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="nemo" data-topic="Workflow" data-id="tidy"><a href='../../nemo/html/Workflow.html#method-Workflow-tidy'><code>nemo::Workflow$tidy()</code></a></span></li>

--- a/man/parse_file.Rd
+++ b/man/parse_file.Rd
@@ -27,7 +27,7 @@ Parses files.
 \examples{
 path <- system.file("extdata/tool1", package = "nemo")
 x <- Tool$new("tool1", pkg = "nemo", path)
-schemas_all <- x$raw_schemas_all
+schemas_all <- x$schemas_raw
 f <- function(ver, tbl) file.path(path, ver, paste0("sampleA.tool1.", tbl, ".tsv"))
 # table1: three versions with different column sets
 (d1_v123 <- parse_file(f("v1.2.3", "table1"), "table1", schemas_all))

--- a/man/parse_file_keyvalue.Rd
+++ b/man/parse_file_keyvalue.Rd
@@ -27,7 +27,7 @@ Parses files with no header and two columns representing key-value pairs.
 \examples{
 path <- system.file("extdata/tool1", package = "nemo")
 x <- Tool1$new(path)
-schemas_all <- x$raw_schemas_all
+schemas_all <- x$schemas_raw
 pname <- "table3"
 f <- function(ver) file.path(path, ver, "sampleA.tool1.table3.tsv")
 # v1.0.0: 3 key-value pairs (SampleID, QCStatus, TotalReads)

--- a/man/parse_file_nohead.Rd
+++ b/man/parse_file_nohead.Rd
@@ -24,7 +24,7 @@ Parses files with no column names.
 \examples{
 path <- system.file("extdata/tool1", package = "nemo")
 x <- Tool$new("tool1", pkg = "nemo", path)
-schemas_all <- x$raw_schemas_all
+schemas_all <- x$schemas_raw
 pname <- "table4"
 fpath_latest <- file.path(path, "latest", "sampleA.tool1.table4.tsv")
 fpath_v1 <- file.path(path, "v1.0.0", "sampleA.tool1.table4.tsv")

--- a/man/schema_guess.Rd
+++ b/man/schema_guess.Rd
@@ -28,7 +28,7 @@ pname <- "table1"
 cnames1 <- file_hdr(fpath1)
 cnames2 <- file_hdr(fpath2)
 conf <- Config$new("tool1", pkg = "nemo")
-schemas_all <- conf$get_schemas_all("raw")
+schemas_all <- conf$get_schemas_raw()
 (s1 <- schema_guess(pname, cnames1, schemas_all))
 (s2 <- schema_guess(pname, cnames2, schemas_all))
 

--- a/tests/testthat/test-roxytest-testexamples-Config.R
+++ b/tests/testthat/test-roxytest-testexamples-Config.R
@@ -11,12 +11,12 @@ test_that("Function Config() @ L57", {
   (ftypes <- conf$get_ftypes())
   (ftype1 <- conf$get_ftype("table1"))
   (descr <- conf$get_descriptions())
-  (rs <- conf$get_schemas_all("raw"))
-  (ts <- conf$get_schemas_all("tidy"))
-  (s1 <- conf$get_schema("table1"))
-  conf$get_schema("table1", v = "v1.2.3")
-  conf$get_schema("table1", raw_or_tidy = "tidy")
-  conf$are_schemas_valid()
+  (rs <- conf$get_schemas_raw())
+  (ts <- conf$get_schemas_tidy())
+  (s1 <- conf$get_schema_raw("table1"))
+  conf$get_schema_raw("table1", v = "v1.2.3")
+  conf$get_schema_tidy("table1")
+  conf$validate_schemas()
   (cm <- conf$get_col_map("table5"))
   
   # initialize
@@ -29,23 +29,23 @@ test_that("Function Config() @ L57", {
   expect_equal(ftype1, "txt")
   # get_descriptions
   expect_equal(nrow(descr), 6)
-  # get_schemas_all
+  # get_schemas_raw / get_schemas_tidy
   expect_equal(dplyr::filter(rs, .data$name == "table1") |> nrow(), 3)
   expect_equal(dplyr::filter(ts, .data$name == "table1") |> nrow(), 3)
-  # get_schema
+  # get_schema_raw
   expect_named(s1, c("version", "field", "type"))
-  expect_equal(nrow(conf$get_schema("table1", v = "v1.2.3")), 5)
-  expect_equal(nrow(conf$get_schema("table1", v = "v4.5.6")), 4)
-  expect_error(conf$get_schema("foo"))
-  expect_error(conf$get_schema("table1", v = "foo"))
-  # are_schemas_valid
-  expect_true(conf$are_schemas_valid())
+  expect_equal(nrow(conf$get_schema_raw("table1", v = "v1.2.3")), 5)
+  expect_equal(nrow(conf$get_schema_raw("table1", v = "v4.5.6")), 4)
+  expect_error(conf$get_schema_raw("foo"))
+  expect_error(conf$get_schema_raw("table1", v = "foo"))
+  # validate_schemas
+  expect_true(conf$validate_schemas())
   # get_col_map
   expect_named(cm, c("raw", "tidy", "type", "description"))
 })
 
 
-test_that("Function config_prep_raw_schema() @ L330", {
+test_that("Function config_prep_raw_schema() @ L346", {
   
   path <- system.file("extdata", "tool1/latest/sampleA.tool1.table1.tsv", package = "nemo")
   (x <- config_prep_raw_schema(path = path, delim = "\t"))
@@ -53,7 +53,7 @@ test_that("Function config_prep_raw_schema() @ L330", {
 })
 
 
-test_that("Function config_prep_raw() @ L375", {
+test_that("Function config_prep_raw() @ L391", {
   
   path <- system.file("extdata", "tool1/latest/sampleA.tool1.table1.tsv", package = "nemo")
   name <- "table1"

--- a/tests/testthat/test-roxytest-testexamples-Workflow.R
+++ b/tests/testthat/test-roxytest-testexamples-Workflow.R
@@ -14,7 +14,7 @@ test_that("Function Workflow() @ L61", {
   wf$filter_files(exclude = "tool1_table5")
   wf$tidy()
   (tbls <- wf$get_tbls())
-  (rs <- wf$get_raw_schemas_all())
+  (rs <- wf$get_schemas_raw())
   dir1 <- fs::file_temp(); dir2 <- fs::file_temp()
   wf$write(output_dir = dir1, format = "parquet", input_id = "run1")
   (lf1 <- list.files(dir1, pattern = "tool1.*parquet", full.names = TRUE))
@@ -33,7 +33,7 @@ test_that("Function Workflow() @ L61", {
   expect_false("tool1_table5" %in% tbls$tool_parser)
   expect_true("tool1_table4" %in% tbls$tool_parser)
   expect_named(tbls, c(nms1, "tidy"))
-  # get_raw_schemas_all
+  # get_schemas_raw
   expect_named(rs, c("tool", "name", "tbl_description", "version", "schema"))
   # write: two table4 output files (one per version)
   expect_equal(sum(grepl("table4", basename(lf1))), 2)

--- a/tests/testthat/test-roxytest-testexamples-parse.R
+++ b/tests/testthat/test-roxytest-testexamples-parse.R
@@ -6,7 +6,7 @@ test_that("Function parse_file() @ L43", {
   
   path <- system.file("extdata/tool1", package = "nemo")
   x <- Tool$new("tool1", pkg = "nemo", path)
-  schemas_all <- x$raw_schemas_all
+  schemas_all <- x$schemas_raw
   f <- function(ver, tbl) file.path(path, ver, paste0("sampleA.tool1.", tbl, ".tsv"))
   # table1: three versions with different column sets
   (d1_v123 <- parse_file(f("v1.2.3", "table1"), "table1", schemas_all))
@@ -35,7 +35,7 @@ test_that("Function parse_file_nohead() @ L100", {
   
   path <- system.file("extdata/tool1", package = "nemo")
   x <- Tool$new("tool1", pkg = "nemo", path)
-  schemas_all <- x$raw_schemas_all
+  schemas_all <- x$schemas_raw
   pname <- "table4"
   fpath_latest <- file.path(path, "latest", "sampleA.tool1.table4.tsv")
   fpath_v1 <- file.path(path, "v1.0.0", "sampleA.tool1.table4.tsv")
@@ -76,7 +76,7 @@ test_that("Function schema_guess() @ L186", {
   cnames1 <- file_hdr(fpath1)
   cnames2 <- file_hdr(fpath2)
   conf <- Config$new("tool1", pkg = "nemo")
-  schemas_all <- conf$get_schemas_all("raw")
+  schemas_all <- conf$get_schemas_raw()
   (s1 <- schema_guess(pname, cnames1, schemas_all))
   (s2 <- schema_guess(pname, cnames2, schemas_all))
   
@@ -90,7 +90,7 @@ test_that("Function parse_file_keyvalue() @ L248", {
   
   path <- system.file("extdata/tool1", package = "nemo")
   x <- Tool1$new(path)
-  schemas_all <- x$raw_schemas_all
+  schemas_all <- x$schemas_raw
   pname <- "table3"
   f <- function(ver) file.path(path, ver, "sampleA.tool1.table3.tsv")
   # v1.0.0: 3 key-value pairs (SampleID, QCStatus, TotalReads)

--- a/vignettes/NEWS.qmd
+++ b/vignettes/NEWS.qmd
@@ -68,6 +68,21 @@ pr <- function(n) {
 
 ### API
 
+- Rename `out_dir` => `output_dir` across `Tool$write/wrangle`, `Workflow$write/wrangle`,
+  `cli_nemo_tidy`, and `nemo_uml`; CLI flag `--out_dir` => `--output_dir`
+- Rename `pfix_include` => `prefix_include` across `Tool$write/wrangle`,
+  `Workflow$write/wrangle`, and `cli_nemo_tidy`; output column `input_pfix` =>
+  `input_prefix`
+- `Config`: rename `config` field => `tables`; `raw_schemas_all` field =>
+  `schemas_raw`; `get_schemas_all(raw_or_tidy)` => `get_schemas_raw()` /
+  `get_schemas_tidy()` / `get_schemas_both()`; `get_schema(x, v, raw_or_tidy)` =>
+  `get_schema_raw(x, v)` / `get_schema_tidy(x, v)`; `are_schemas_valid()` =>
+  `validate_schemas()`
+- `Tool`: rename fields `raw_schemas_all` => `schemas_raw`, `tidy_schemas_all` =>
+  `schemas_tidy`, `get_tidy_schema` => `get_schema_tidy`, `get_raw_schema` =>
+  `get_schema_raw`
+- `Workflow`: rename `get_raw_schemas_all()` => `get_schemas_raw()`,
+  `get_tidy_schemas_all()` => `get_schemas_tidy()`
 - `Tool$write`, `Workflow$write`, `Workflow$nemofy`: add `pfix_include` argument
   (default `FALSE`) to control whether `input_pfix` is prepended to tidy tables
 - `Tool`: refactor parse/tidy dispatch — subclasses can now override per-table

--- a/vignettes/schema_walkthrough.qmd
+++ b/vignettes/schema_walkthrough.qmd
@@ -148,8 +148,8 @@ conf$get_ftypes() |> kable()
 ### Versioned raw schemas (used by `nemo::schema_guess`)
 
 ```{r}
-#| label: get_schemas_all
-conf$get_schemas_all() |>
+#| label: get_schemas_raw
+conf$get_schemas_raw() |>
   select("name", "version", "schema")
 ```
 
@@ -157,7 +157,7 @@ The `schema` list-col holds the `(field, type)` pairs used when reading a file:
 
 ```{r}
 #| label: get_schema_table1_raw
-conf$get_schema("table1", v = "v1.2.3", raw_or_tidy = "raw") |>
+conf$get_schema_raw("table1", v = "v1.2.3") |>
   select("field", "type") |>
   kable()
 ```
@@ -166,7 +166,7 @@ conf$get_schema("table1", v = "v1.2.3", raw_or_tidy = "raw") |>
 
 ```{r}
 #| label: get_schema_table1_tidy
-conf$get_schema("table1", raw_or_tidy = "tidy", v = "latest") |> kable()
+conf$get_schema_tidy("table1", v = "latest") |> kable()
 ```
 
 ### Column map for `csv-nohead-long` tables


### PR DESCRIPTION
- Config: config field => tables; raw_schemas_all => schemas_raw; split get_schemas_all/get_schema into get_schemas_raw/tidy/both and get_schema_raw/tidy over private helpers;
are_schemas_valid => validate_schemas
- Tool: raw_schemas_all => schemas_raw, tidy_schemas_all => schemas_tidy, get_tidy_schema => get_schema_tidy, get_raw_schema => get_schema_raw
- Workflow: get_raw_schemas_all => get_schemas_raw, get_tidy_schemas_all => get_schemas_tidy