### PR TITLE
Tool: rename txt ftypes to tsv, add extra_ftypes hook

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -48,6 +48,19 @@ Two-tier approach:
   auto-generated into `tests/testthat/test-roxytest-testexamples-<file>.R` by
   `devtools::document()`. Never edit those generated files directly.
 
+## ftypes (`schema.yaml` → `parse_by_ftype`)
+
+Built-in ftypes handled by `Tool$parse_by_ftype()`:
+
+| ftype | parser | delimiter |
+|-------|--------|-----------|
+| `tsv` | `parse_file` | `\t` |
+| `csv` | `parse_file` | `,` |
+| `tsv-nohead` | `parse_file_nohead` | `\t` |
+| `tsv-keyvalue` | `parse_file_keyvalue` | `\t` |
+
+Child packages add pkg-specific ftypes by overriding `private$extra_ftypes()` — return a named list of `ftype -> function(x, table_name)`. Checked before the switch; unknown ftypes fall through to `nemo_stop`.
+
 ## Critical gotchas
 
 - TODO tracked in `.claude/TODO.md`

--- a/R/Tool.R
+++ b/R/Tool.R
@@ -171,19 +171,25 @@ Tool <- R6::R6Class(
         private$tidy_file(x, table_name)
       }
     },
+    # Hook for subclasses to register pkg-specific ftype parsers without
+    # overriding parse_by_ftype. Return a named list of ftype -> function(x, table_name).
+    extra_ftypes = function() list(),
     # Parse a file by looking up its ftype from the config.
     parse_by_ftype = function(x, table_name) {
       ftype <- self$config$get_ftype(table_name)
+      extras <- private$extra_ftypes()
+      if (ftype %in% names(extras)) {
+        return(extras[[ftype]](x, table_name))
+      }
       switch(
         ftype,
-        "txt" = private$parse_file(x, table_name),
+        "tsv" = private$parse_file(x, table_name),
         "csv" = private$parse_file(x, table_name, delim = ","),
-        "txt-nohead" = private$parse_file_nohead(x, table_name),
-        "txt-keyvalue" = private$parse_file_keyvalue(x, table_name),
-        "txt-keyvalue-eq" = private$parse_file_keyvalue(x, table_name, delim = "="),
+        "tsv-nohead" = private$parse_file_nohead(x, table_name),
+        "tsv-keyvalue" = private$parse_file_keyvalue(x, table_name),
         nemo_stop(glue(
           "No default parser for ftype '{ftype}' (table '{table_name}'). ",
-          "Define parse_{table_name}() in the subclass."
+          "Define parse_{table_name}() in the subclass or register it via extra_ftypes()."
         ))
       )
     },

--- a/inst/config/tools/tool1/schema.yaml
+++ b/inst/config/tools/tool1/schema.yaml
@@ -2,7 +2,7 @@ tables:
   table1:
     description: 'Table1 for tool1 (txt: header present, tab-delimited).'
     pattern: "\\.tool1\\.table1\\.tsv$"
-    ftype: 'txt'
+    ftype: 'tsv'
     columns:
       - raw: 'SampleID'
         tidy: 'sample_id'
@@ -42,7 +42,7 @@ tables:
   table2:
     description: 'Table2 for tool1 (txt: header present, tab-delimited).'
     pattern: "\\.tool1\\.table2\\.tsv$"
-    ftype: 'txt'
+    ftype: 'tsv'
     columns:
       - raw: 'SampleID'
         tidy: 'sample_id'
@@ -62,7 +62,7 @@ tables:
   table3:
     description: 'Table3 for tool1 (txt-keyvalue: no header, 2 cols, col1=key col2=value).'
     pattern: "\\.tool1\\.table3\\.tsv$"
-    ftype: 'txt-keyvalue'
+    ftype: 'tsv-keyvalue'
     columns:
       - raw: 'SampleID'
         tidy: 'sample_id'
@@ -92,7 +92,7 @@ tables:
   table4:
     description: 'Table4 for tool1 (txt-nohead: no header, positional cols X1..XN).'
     pattern: "\\.tool1\\.table4\\.tsv$"
-    ftype: 'txt-nohead'
+    ftype: 'tsv-nohead'
     columns:
       - raw: 'X1'
         tidy: 'sample_id'

--- a/tests/testthat/test-Config.R
+++ b/tests/testthat/test-Config.R
@@ -8,7 +8,7 @@ test_that("Config pattern and ftype methods", {
   expect_equal(nrow(conf$get_patterns()), 6)
   expect_equal(conf$get_pattern("table1"), "\\.tool1\\.table1\\.tsv$")
   expect_equal(dplyr::distinct(conf$get_ftypes(), .data$ftype) |> nrow(), 5)
-  expect_equal(conf$get_ftype("table1"), "txt")
+  expect_equal(conf$get_ftype("table1"), "tsv")
 })
 
 test_that("Config description methods", {

--- a/vignettes/NEWS.qmd
+++ b/vignettes/NEWS.qmd
@@ -104,7 +104,7 @@ Major refactor.
 - `nemo_gha_mermaid()`: generates a Mermaid flowchart of the full CI/CD pipeline (`r pr(52)`)
 - `nemo_uml()`: generates a PlantUML SVG from R6 class names
 - `nemo_schema_reactable()` / `nemo_schemavis_data()`: interactive schema explorer
-- New file types: `txt-nohead`, `txt-keyvalue`, `csv`, `csv-nohead-long`
+- New file types: `tsv-nohead`, `tsv-keyvalue`, `csv`, `csv-nohead-long`
 - `tidy`: `--output_id` / `--ulid` flags for tagging outputs with a run identifier;
   `--max` flag on `list` subcommand
 - Metadata exported to `metadata.parquet` per run (`r pr(62)`, `r iss(61)`)

--- a/vignettes/new-tool.qmd
+++ b/vignettes/new-tool.qmd
@@ -32,7 +32,7 @@ d1 <- here(glue("inst/extdata/{tool}/latest"))
 
 x <- tribble(
   ~name     , ~descr                 , ~pat                        , ~type  , ~path                                       ,
-  "table1"  , "table1 description."  , "\\.mytool\\.table1\\.tsv$" , "txt"  , file.path(d1, "sampleA.mytool.table1.tsv")  ,
+  "table1"  , "table1 description."  , "\\.mytool\\.table1\\.tsv$" , "tsv"  , file.path(d1, "sampleA.mytool.table1.tsv")  ,
   "table2"  , "table2 description."  , "\\.mytool\\.table2\\.csv$" , "csv"  , file.path(d1, "sampleA.mytool.table2.csv")  ,
 )
 

--- a/vignettes/structure.Rmd
+++ b/vignettes/structure.Rmd
@@ -103,13 +103,15 @@ tables:
 
 The `ftype` field signals how the file is parsed:
 
-| `ftype`           | Description                                        | `raw:` names                            | Parser                   |
-|-------------------|----------------------------------------------------|-----------------------------------------|--------------------------|
-| `txt`             | Header present; tab-delimited                      | actual column names                     | `parse_file`             |
-| `csv`             | Header present; comma-delimited                    | actual column names                     | `parse_file` (delim=`,`) |
-| `txt-nohead`      | No header; positional columns                      | `X1, X2, …, XN`                        | `parse_file_nohead`      |
-| `txt-keyvalue`    | No header; 2 cols (key, value); pivoted wide       | actual key values                       | `parse_file_keyvalue`    |
-| `csv-nohead-long` | No header; long format; custom pivot               | metric names (values in the key column) | custom `tidy_*` method   |
+| `ftype`           | Description                                        | `raw:` names                            | Parser                      |
+|-------------------|----------------------------------------------------|-----------------------------------------|-----------------------------|
+| `tsv`             | Header present; tab-delimited                      | actual column names                     | `parse_file`                |
+| `csv`             | Header present; comma-delimited                    | actual column names                     | `parse_file` (delim=`,`)    |
+| `tsv-nohead`      | No header; positional columns                      | `X1, X2, …, XN`                        | `parse_file_nohead`         |
+| `tsv-keyvalue`    | No header; 2 cols (key, value); pivoted wide       | actual key values                       | `parse_file_keyvalue`       |
+| `csv-nohead-long` | No header; long format; custom pivot               | metric names (values in the key column) | custom `tidy_*` method      |
+
+Child packages can register additional ftypes by overriding `private$extra_ftypes()` — return a named list of `ftype -> function(x, table_name)`. These are checked before the built-in switch.
 
 The `versions` array on each column lists every tool version that column appears
 in, giving a full picture of additions and removals:


### PR DESCRIPTION
- txt/txt-nohead/txt-keyvalue/txt-keyvalue-eq => tsv*/equal-keyvalue
- `extra_ftypes()` private hook lets child pkgs register pkg-specific ftypes without overriding `parse_by_ftype()`