### PR TITLE
Output naming: `refine_files` hook + naming vignette

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,9 +1,10 @@
-# CLAUDE.md — nemo
+# CLAUDE.md --- nemo
 
 ## What this is
 
-Base R package providing R6 classes (`Tool`, `Workflow`, `Config`) inherited by all tidywf parsing R packages.
-For deep context use the routing table in `tidywf/CLAUDE.md` — auto-loaded by Claude Code from the parent directory.
+Base R package providing R6 classes (`Tool`, `Workflow`, `Config`) inherited by
+all tidywf parsing R packages. For deep context use the routing table in
+`tidywf/CLAUDE.md` --- auto-loaded by Claude Code from the parent directory.
 
 ## Repo layout
 
@@ -34,82 +35,103 @@ nemo
 
 ## Reference implementations
 
-`Tool1` (`R/Tool1.R`) and `Workflow1` (`R/Workflow1.R`) are the canonical examples — follow these
-when creating new tools or workflows. They demonstrate the full pattern: schema config,
-file discovery, raw parsing, and tidy output.
+`Tool1` (`R/Tool1.R`) and `Workflow1` (`R/Workflow1.R`) are the canonical
+examples --- follow these when creating new tools or workflows. They demonstrate
+the full pattern: schema config, file discovery, raw parsing, and tidy output.
 
 ## Testing
 
 Two-tier approach:
 
-- **R6 classes** (`Tool`, `Tool1`, `Workflow`, `Workflow1`, `Config`) — standalone files in
-  `tests/testthat/test-<ClassName>.R`, written manually with proper `test_that` blocks.
-- **Pure helper functions** (everything else) — `@testexamples` blocks in the source file,
-  auto-generated into `tests/testthat/test-roxytest-testexamples-<file>.R` by
+- **R6 classes** (`Tool`, `Tool1`, `Workflow`, `Workflow1`, `Config`) ---
+  standalone files in `tests/testthat/test-<ClassName>.R`, written manually with
+  proper `test_that` blocks.
+- **Pure helper functions** (everything else) --- `@testexamples` blocks in the
+  source file, auto-generated into
+  `tests/testthat/test-roxytest-testexamples-<file>.R` by
   `devtools::document()`. Never edit those generated files directly.
 
 ## ftypes (`schema.yaml` → `parse_by_ftype`)
 
 Built-in ftypes handled by `Tool$parse_by_ftype()`:
 
-| ftype | parser | delimiter |
-|-------|--------|-----------|
-| `tsv` | `parse_file` | `\t` |
-| `csv` | `parse_file` | `,` |
-| `tsv-nohead` | `parse_file_nohead` | `\t` |
-| `tsv-keyvalue` | `parse_file_keyvalue` | `\t` |
+| ftype          | parser                | delimiter |
+| -------------- | --------------------- | --------- |
+| `tsv`          | `parse_file`          | `\t`      |
+| `csv`          | `parse_file`          | `,`       |
+| `tsv-nohead`   | `parse_file_nohead`   | `\t`      |
+| `tsv-keyvalue` | `parse_file_keyvalue` | `\t`      |
 
-Child packages add pkg-specific ftypes by overriding `private$extra_ftypes()` — return a named list of `ftype -> function(x, table_name)`. Checked before the switch; unknown ftypes fall through to `nemo_stop`.
+Child packages add pkg-specific ftypes by overriding `private$extra_ftypes()`
+--- return a named list of `ftype -> function(x, table_name)`. Checked before
+the switch; unknown ftypes fall through to `nemo_stop`.
+
+## Subclass hooks
+
+Extension points a `Tool` subclass may override in `private`:
+
+- `extra_ftypes()` --- register pkg-specific ftype parsers (see above).
+- `refine_files(files)` --- adjust the matched-files tibble inside
+  `compute_files()`, applied to the **base prefix before** the disambiguation
+  passes. Use it to fold a semantic distinction (e.g. germline/somatic) into
+  `prefix` so those files no longer collide and don't pick up a spurious
+  `_2`/`_3`. Receives
+  `parser/bname/size/lastmodified/path/pattern/prefix/tool_parser`; default is a
+  no-op. `Linx`/`Purple` in tidywigits use it. (Renamed from
+  `post_process_files`; note it now runs *before*, not after, disambiguation.)
 
 ## Critical gotchas
 
 - TODO tracked in `.claude/TODO.md`
-- Schema methods (`get_schema_raw`, `get_schema_tidy`, `get_col_map`) live on `Config`, not `Tool`. In subclass `tidy_*` methods use `self$config$get_col_map(...)`
-- Use accessor methods, not direct field access: `list_files()` not `$files`, `get_tbls()` not `$tbls`.
+- Schema methods (`get_schema_raw`, `get_schema_tidy`, `get_col_map`) live on
+  `Config`, not `Tool`. In subclass `tidy_*` methods use
+  `self$config$get_col_map(...)`
+- Use accessor methods, not direct field access: `list_files()` not `$files`,
+  `get_tbls()` not `$tbls`.
 
 ## CLI (`R/cli.R`, `inst/cli/nemo.R`)
 
 Built with `argparse` via `nemo_cli()`. Two subcommands:
 
-| Subcommand | Key args | What it does |
-|------------|----------|--------------|
-| `list` | `-d IN_DIR -f FORMAT` | Lists parsable files; output as `pretty` or `tsv` |
-| `tidy` | `-d IN_DIR -o OUT_DIR -f FORMAT` | Runs `run()` and writes tidy outputs |
+| Subcommand | Key args                         | What it does                                      |
+| ---------- | -------------------------------- | ------------------------------------------------- |
+| `list`     | `-d IN_DIR -f FORMAT`            | Lists parsable files; output as `pretty` or `tsv` |
+| `tidy`     | `-d IN_DIR -o OUT_DIR -f FORMAT` | Runs `run()` and writes tidy outputs              |
 
-Both accept `-w WORKFLOW` and `-q` (quiet). `tidy` also accepts:
-- `--input_id` — adds an `input_id` column to all output tables
-- `--output_id` / `--ulid` — adds an `output_id` column (mutually exclusive; `--ulid` generates one automatically)
-- `--prefix_include` — adds an `input_prefix` column derived from the input filename prefix
-- `--include`/`--exclude` — filter tool parsers (comma-separated)
-- `--dbname`/`--dbuser` — required when `--format db`
+Both accept `-w WORKFLOW` and `-q` (quiet). `tidy` also accepts: - `--input_id`
+--- adds an `input_id` column to all output tables - `--output_id` / `--ulid`
+--- adds an `output_id` column (mutually exclusive; `--ulid` generates one
+automatically) - `--prefix_include` --- adds an `input_prefix` column derived
+from the input filename prefix - `--include`/`--exclude` --- filter tool parsers
+(comma-separated) - `--dbname`/`--dbuser` --- required when `--format db`
 
 ## Logging (`R/log.R`)
 
-`log4r`-based, initialised in `.onLoad`. Env vars:
-- `NEMO_LOG_ENABLE` — `"FALSE"` to disable (default `"TRUE"`)
-- `NEMO_LOG_LEVEL` — `"DEBUG"`, `"INFO"` (default), `"WARN"`, `"ERROR"`, `"FATAL"`
+`log4r`-based, initialised in `.onLoad`. Env vars: - `NEMO_LOG_ENABLE` ---
+`"FALSE"` to disable (default `"TRUE"`) - `NEMO_LOG_LEVEL` --- `"DEBUG"`,
+`"INFO"` (default), `"WARN"`, `"ERROR"`, `"FATAL"`
 
 Public API: `nemo_log(level, msg, ...)` (sprintf-style), `nemo_log_date()`.
 
 ## Key API (`R/`)
 
-| Function | File | Purpose |
-|----------|------|---------|
-| `nemo_write(d, fpfix, format, dbconn, dbtab)` | `write.R` | Dispatches to correct writer by format |
-| `nemo_osfx(fpfix, format)` | `write.R` | Constructs output path with right extension |
-| `nemo_out_formats()` | `write.R` | Returns valid format strings: `parquet`, `db`, `tsv`, `csv`, `rds` |
-| `nemo_metadata(files, pkgs, ...)` | `metadata.R` | Assembles run-level metadata as a single-row tibble written to `metadata.parquet` |
-| `nemo_schema_reactable(tools, pkg, ...)` | `schema_vis.R` | Interactive reactable schema explorer |
-| `nemo_schemavis_data(tools, pkg)` | `schema_vis.R` | Per-table schema tibble (versions, columns) |
-| `nemo_gha_mermaid(actions_url, deploy_yaml)` | `gha.R` | Builds Mermaid CI/CD flowchart from local + remote YAML |
-| `nemo_uml()` | `uml.R` | Generates PlantUML SVG from R6 class names |
+| Function                                      | File           | Purpose                                                                           |
+| --------------------------------------------- | -------------- | --------------------------------------------------------------------------------- |
+| `nemo_write(d, fpfix, format, dbconn, dbtab)` | `write.R`      | Dispatches to correct writer by format                                            |
+| `nemo_osfx(fpfix, format)`                    | `write.R`      | Constructs output path with right extension                                       |
+| `nemo_out_formats()`                          | `write.R`      | Returns valid format strings: `parquet`, `db`, `tsv`, `csv`, `rds`                |
+| `nemo_metadata(files, pkgs, ...)`             | `metadata.R`   | Assembles run-level metadata as a single-row tibble written to `metadata.parquet` |
+| `nemo_schema_reactable(tools, pkg, ...)`      | `schema_vis.R` | Interactive reactable schema explorer                                             |
+| `nemo_schemavis_data(tools, pkg)`             | `schema_vis.R` | Per-table schema tibble (versions, columns)                                       |
+| `nemo_gha_mermaid(actions_url, deploy_yaml)`  | `gha.R`        | Builds Mermaid CI/CD flowchart from local + remote YAML                           |
+| `nemo_uml()`                                  | `uml.R`        | Generates PlantUML SVG from R6 class names                                        |
 
 ## Dev commands
 
 ```r
 devtools::load_all()
 devtools::test()
-devtools::document()   # also regenerates roxytest test files
+devtools::document() # also regenerates roxytest test files
 devtools::check()
 
 path <- system.file("extdata/tool1", package = "nemo")

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -98,18 +98,20 @@ Built with `argparse` via `nemo_cli()`. Two subcommands:
 | `list`     | `-d IN_DIR -f FORMAT`            | Lists parsable files; output as `pretty` or `tsv` |
 | `tidy`     | `-d IN_DIR -o OUT_DIR -f FORMAT` | Runs `run()` and writes tidy outputs              |
 
-Both accept `-w WORKFLOW` and `-q` (quiet). `tidy` also accepts: - `--input_id`
---- adds an `input_id` column to all output tables - `--output_id` / `--ulid`
---- adds an `output_id` column (mutually exclusive; `--ulid` generates one
-automatically) - `--prefix_include` --- adds an `input_prefix` column derived
-from the input filename prefix - `--include`/`--exclude` --- filter tool parsers
-(comma-separated) - `--dbname`/`--dbuser` --- required when `--format db`
+Both accept `-w WORKFLOW` and `-q` (quiet). `tidy` also accepts:
+
+- `--input_id` — adds an `input_id` column to all output tables
+- `--output_id` / `--ulid` — adds an `output_id` column (mutually exclusive; `--ulid` generates one automatically)
+- `--prefix_include` — adds an `input_prefix` column derived from the input filename prefix
+- `--include`/`--exclude` — filter tool parsers (comma-separated)
+- `--dbname`/`--dbuser` — required when `--format db`
 
 ## Logging (`R/log.R`)
 
-`log4r`-based, initialised in `.onLoad`. Env vars: - `NEMO_LOG_ENABLE` ---
-`"FALSE"` to disable (default `"TRUE"`) - `NEMO_LOG_LEVEL` --- `"DEBUG"`,
-`"INFO"` (default), `"WARN"`, `"ERROR"`, `"FATAL"`
+`log4r`-based, initialised in `.onLoad`. Env vars:
+
+- `NEMO_LOG_ENABLE` — "FALSE" to disable (default "TRUE")
+- `NEMO_LOG_LEVEL` — "DEBUG", "INFO" (default), "WARN", "ERROR", "FATAL"
 
 Public API: `nemo_log(level, msg, ...)` (sprintf-style), `nemo_log_date()`.
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ readme:
 	@quarto render README.qmd
 
 pkgdown:
-	@R -e "pkgdown::build_site()" --quiet --no-restore --no-save && mv docs nogit/pkgdown_site/ && open nogit/pkgdown_site/docs/dev/index.html
+	@R -e "pkgdown::build_site()" --quiet --no-restore --no-save
 
 readme-pkgdown: readme pkgdown
 

--- a/R/Tool.R
+++ b/R/Tool.R
@@ -58,7 +58,10 @@ Tool <- R6::R6Class(
     files_tbl = NULL,
     # Typed empty tibble for compute_files; kept as a method so the column spec
     # is in one place and easy to update if the schema changes.
-    post_process_files = function(files) files,
+    # Subclass hook to adjust the matched-files tibble before disambiguation.
+    # Receives columns parser/bname/size/lastmodified/path/pattern/prefix/
+    # tool_parser; typically rewrites `prefix`. Default is a no-op.
+    refine_files = function(files) files,
     empty_files_tbl = function() {
       tibble::tibble(
         tool_parser = character(),
@@ -91,13 +94,18 @@ Tool <- R6::R6Class(
         return(private$empty_files_tbl())
       }
       res <- res |>
-        dplyr::select("parser", "bname", "size", "lastmodified", "path", "pattern")
-      res |>
+        dplyr::select("parser", "bname", "size", "lastmodified", "path", "pattern") |>
         dplyr::mutate(
           prefix = stringr::str_remove(.data$bname, .data$pattern),
           prefix = dplyr::if_else(.data$prefix == "", .data$parser, .data$prefix),
           tool_parser = paste0(self$name, "_", .data$parser)
-        ) |>
+        )
+      # Subclass hook, applied to the base prefix *before* the disambiguation
+      # passes below. Running it here (rather than on the final tibble) lets a
+      # subclass fold a semantic distinction (e.g. germline vs somatic) into the
+      # prefix so those files no longer collide, avoiding a spurious _2/_3.
+      res <- private$refine_files(res)
+      res |>
         dplyr::mutate(prefix_suffix = dplyr::row_number(), .by = "bname") |>
         dplyr::mutate(
           prefix_suffix = dplyr::if_else(
@@ -297,7 +305,7 @@ Tool <- R6::R6Class(
       self$path <- if (!is.null(path)) normalizePath(path) else NULL
       self$config <- Config$new(self$name, pkg = self$pkg)
       private$files_tbl <- files_tbl
-      private$files <- private$post_process_files(private$compute_files())
+      private$files <- private$compute_files()
     },
     #' @description Print details about the Tool.
     #' @param ... (ignored).

--- a/inst/doc-templates/vignettes/_output_naming.qmd
+++ b/inst/doc-templates/vignettes/_output_naming.qmd
@@ -1,0 +1,144 @@
+When the same sample is processed more than once (e.g. repeat runs of a tool
+over different dates), you end up with several sets of raw outputs that share
+**identical file names** but live under **different parent folders**. Here we
+show: (a) how tidy outputs are named so that repeated runs avoid overwriting
+each other, and (b) how to carry a run identifier *into the data* so the runs
+are still distinguishable once the files have been merged into a parquet dataset
+or database.
+
+## Anatomy of a tidy filename
+
+Every tidy file is named:
+
+```
+{output_dir}/{prefix}_{tool}_{parser}.{ext}
+```
+
+- `{output_dir}`: the directory to output the tidy files in a flat structure.
+- `{prefix}`: the input file's basename with the table's schema `pattern`
+  stripped off. For `sampleA.tool1.table1.tsv` the `table1` pattern
+  (`\.tool1\.table1\.tsv$`) is removed, leaving `sampleA`.
+- `{tool}_{parser}`: the tool name and the matched table (e.g. `tool1_table1`).
+- `{ext}`: driven by `format`
+  (`r nemo::nemo_out_formats() |> glue::glue_collapse(sep = ", ", last = " or ")`).
+
+So `sampleA.tool1.table1.tsv` tidied in parquet format becomes
+`sampleA_tool1_table1.parquet`.
+
+## A repeated sample
+
+Let us simulate three runs of the same sample by copying one tool's outputs into
+separate folders. Each run holds the same files:
+
+```{r}
+#| label: build-runs
+
+src <- system.file("extdata/tool1/latest", package = "nemo")
+dir1 <- path(tempdir(), "naming-demo")
+dir_runs <- path(dir1, "runs")
+run_ids <- c("run1", "run2", "run3")
+
+for (r in run_ids) {
+  dest <- dir_create(path(dir_runs, r))
+  file_copy(dir_ls(src, regexp = "table[12]\\.tsv$"), dest, overwrite = TRUE)
+}
+
+dir_tree(dir_runs)
+```
+
+### Mode A: one recursive tidy
+
+Point a single `Tool1` at the *parent* of the run folders. `list_files()`
+recurses into all three and, because the basenames collide, appends `_2` / `_3`
+to disambiguate the prefixes:
+
+```{r}
+#| label: modeA-listfiles
+
+tool <- Tool1$new(path = dir_runs)
+tool$list_files() |>
+  dplyr::select(bname, parser, prefix)
+```
+
+As you can see, the files share a basename but get prefixes `sampleA`,
+`sampleA_2`, `sampleA_3`. Writing them out, nothing gets overwritten:
+
+```{r}
+#| label: modeA-write
+
+dir_outA <- dir_create(path(dir1, "outA"))
+tool$run(
+  input_id = "input1",
+  output_dir = dir_outA,
+  format = "parquet",
+  prefix_include = TRUE
+)
+
+dir_tree(dir_outA)
+```
+
+The `prefix_include` option also writes the prefix as an `input_prefix` column
+in the output file itself, so the source run survives even after the three files
+are read and stacked into one table:
+
+```{r}
+#| label: modeA-merge
+
+dir_ls(dir_outA, regexp = "tool1_table1\\.parquet") |>
+  purrr::map(arrow::read_parquet) |>
+  purrr::list_rbind()
+```
+
+Mode A is the simplest way to dump every tidy run into one folder without
+overwriting each other. Its limit: the tidy call shares a single `input_id`, so
+the only per-run key is the filename-derived `input_prefix`.
+
+### Mode B: per-run tidy
+
+When you want a more meaningful run identifier than e.g. `sampleA_2`, you should
+tidy each run separately and pass a distinct `input_id`. Because the output
+basenames are now identical across runs, write each run to its own output
+subfolder so they don't get overwritten:
+
+```{r}
+#| label: modeB-write
+
+dir_outB <- dir_create(path(dir1, "outB"))
+for (r in run_ids) {
+  Tool1$new(path = path(dir_runs, r))$run(
+    input_id = r,
+    output_dir = path(dir_outB, r),
+    format = "parquet",
+    prefix_include = TRUE
+  )
+}
+
+dir_tree(dir_outB)
+```
+
+Note the same file names in each subfolder. The folder separates them on disk,
+and the `input_id` column keeps them apart once merged:
+
+```{r}
+#| label: modeB-merge
+
+fs::dir_ls(dir_outB, recurse = TRUE, glob = "*tool1_table1.parquet") |>
+  purrr::map(arrow::read_parquet) |>
+  purrr::list_rbind()
+```
+
+For a globally-unique key with no coordination between runs, use
+`output_id = "<your id>"` with e.g. an auto-generated ULID (done automatically
+via the CLI's `--ulid` flag), which would generate an `output_id` column
+alongside `input_id`.
+
+## Rule of thumb
+
+- File names stop repeat runs from overwriting each other on disk automatically
+  via `_2`/`_3` (Mode A), or by writing to per-run folders (Mode B).
+- Provenance columns (`input_prefix`, `input_id`, `output_id`) let you tell the
+  runs apart after the files are merged into one parquet dataset or loaded into
+  a database, where the filename is no longer visible.
+- Use `prefix_include` when one recursive tidy is enough
+- Use `input_id` / `output_id` when each run is better described by an
+  explicitly specified name you can control.

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -28,6 +28,8 @@ navbar:
           href: articles/installation.html
         - text: Structure
           href: articles/structure.html
+        - text: Output Naming
+          href: articles/output_naming.html
         - text: Schema Table
           href: articles/schema_table.html
         - text: New Tool

--- a/tests/testthat/test-Tool.R
+++ b/tests/testthat/test-Tool.R
@@ -231,3 +231,70 @@ test_that("Tool run chains filter + tidy + write and records written_files", {
   expect_false(any(grepl("table5", basename(list.files(out)))))
   expect_true(any(grepl("table1", basename(list.files(out)))))
 })
+
+test_that("refine_files default is a no-op", {
+  # base Tool1 does not override refine_files: prefixes are the plain sample name
+  tool <- Tool$new(name = name, pkg = pkg, path = file.path(path, "latest"))
+  expect_true(all(tool$list_files()$prefix == "sampleA"))
+})
+
+test_that("refine_files is applied before the disambiguation passes", {
+  # Two files under the same parser (table1) but different samples, so their
+  # prefixes (sampleA / sampleB) do not collide on their own.
+  d <- withr::local_tempdir()
+  src <- file.path(path, "latest", "sampleA.tool1.table1.tsv")
+  file.copy(src, file.path(d, "sampleA.tool1.table1.tsv"))
+  file.copy(src, file.path(d, "sampleB.tool1.table1.tsv"))
+
+  # Subclass that collapses every prefix to a single constant. This only makes
+  # the two files collide *if* refine_files runs before the (tool_parser, prefix)
+  # disambiguation pass. If it ran afterwards (the old post_process_files timing),
+  # both would end up as "x" and silently overwrite each other on write.
+  ToolConst <- R6::R6Class(
+    "ToolConst",
+    inherit = Tool1,
+    cloneable = FALSE,
+    private = list(
+      refine_files = function(files) dplyr::mutate(files, prefix = "x")
+    )
+  )
+  lf <- ToolConst$new(path = d)$list_files()
+
+  # collapsed to "x", then disambiguated -> distinct prefixes, nothing clobbered
+  expect_setequal(lf$prefix, c("x", "x_2"))
+  expect_equal(length(unique(lf$prefix)), 2L)
+})
+
+test_that("refine_files can split a prefix collision to avoid a spurious _2", {
+  # Two files under the same parser whose prefixes the generic pass would collapse
+  # to the same value (both "shared"), so it appends a positional _2. A refine
+  # that instead tags each with its sample keeps them apart with no _2.
+  d <- withr::local_tempdir()
+  src <- file.path(path, "latest", "sampleA.tool1.table1.tsv")
+  file.copy(src, file.path(d, "sampleA.tool1.table1.tsv"))
+  file.copy(src, file.path(d, "sampleB.tool1.table1.tsv"))
+
+  Collapse <- R6::R6Class(
+    "Collapse",
+    inherit = Tool1,
+    cloneable = FALSE,
+    private = list(refine_files = function(files) dplyr::mutate(files, prefix = "shared"))
+  )
+  # collapsed -> positional _2 (unavoidable once they share a prefix)
+  expect_setequal(Collapse$new(path = d)$list_files()$prefix, c("shared", "shared_2"))
+
+  Split <- R6::R6Class(
+    "Split",
+    inherit = Tool1,
+    cloneable = FALSE,
+    private = list(
+      refine_files = function(files) {
+        dplyr::mutate(files, prefix = paste0("shared_", sub("\\..*$", "", .data$bname)))
+      }
+    )
+  )
+  # tagged apart before disambiguation -> no _2 suffix anywhere
+  lf <- Split$new(path = d)$list_files()
+  expect_setequal(lf$prefix, c("shared_sampleA", "shared_sampleB"))
+  expect_false(any(grepl("_2$", lf$prefix)))
+})

--- a/vignettes/NEWS.qmd
+++ b/vignettes/NEWS.qmd
@@ -51,7 +51,15 @@ pr <- function(n) {
 
 ## dev
 
-- Add [DVC](https://dvc.org/) support, mostly for child packages
+- Add [DVC](https://dvc.org/) support, mostly for child packages (`r pr(69)`)
+- Tool: rename txt ftypes to tsv, add extra_ftypes hook (`r pr(70)`, `r pr(71)`)
+- Tool: rename `post_process_files` hook to `refine_files`, now applied to the
+  base prefix *before* the disambiguation passes so subclasses can fold a
+  semantic distinction (e.g. germline/somatic) into the prefix and avoid a
+  spurious `_2`/`_3` suffix
+- New `Output Naming` vignette, shared with child packages via
+  `inst/doc-templates/vignettes/_output_naming.qmd`
+- Panache format vignettes (`r pr(72)`)
 
 ## v0.1.0 (2026-06-22)
 

--- a/vignettes/output_naming.qmd
+++ b/vignettes/output_naming.qmd
@@ -1,0 +1,27 @@
+---
+title: "Output Naming"
+knitr:
+  opts_chunk:
+    collapse: true
+    comment: "#>"
+---
+
+```{r}
+#| label: pkgs
+#| include: false
+
+use("nemo")
+use("fs")
+use("arrow", "read_parquet")
+use("purrr", "map")
+use("dplyr")
+
+child1 <- system.file(
+  "doc-templates/vignettes/_output_naming.qmd",
+  package = "nemo"
+)
+```
+
+```{r, child=child1}
+#| label: child-output-naming
+```

--- a/vignettes/structure.Rmd
+++ b/vignettes/structure.Rmd
@@ -308,7 +308,8 @@ additional `input_id` column. This can be used e.g. to distinguish results from
 different samples in a data pipeline. An optional `output_id` column can also be
 added (e.g. to distinguish between runs for the same input sample). An
 `input_prefix` column can be included via `prefix_include = TRUE`, which would
-use the prefix of the file basename.
+use the prefix of the file basename. For more details about output naming
+conventions, see the [output naming](output_naming.html) vignette.
 
 ```{r}
 #| label: tool1_write


### PR DESCRIPTION
Improves how repeated tool outputs get named so files no longer end up with
confusing, lossy names. Adds a vignette explaining the whole naming scheme.

- Renames the hook a tool can use to tweak output names from `post_process_files`
  => `refine_files`, and runs it at a better point so it can prevent naming
  clashes instead of just papering over them.
- Adds an Output Naming vignette, written as a shared template so child
  packages (e.g. tidywigits) can reuse and extend it.

## Why

When the same sample is processed more than once, nemo automatically adds `_2`,
`_3`, etc. to keep output files from overwriting each other. Some tools also emit
two flavours of the same table (for example a germline and a somatic version)
that would otherwise land on the same name.

Previously a tool could only adjust the name *after* nemo had already added its
`_2`, so the two effects piled up into names like `sample1_2_somatic` — and after
a few repeat runs, `sample1_2_2_somatic`. You couldn't easily tell the runs or
the flavours apart.

Now a tool gets to label the flavour *first*, so germline and somatic never clash
in the first place, and each is numbered cleanly on its own:

|                   | before                                              | after                                            |
|-------------------|-----------------------------------------------------|--------------------------------------------------|
| germline (3 runs) | `sample1_germline`, `_2_germline`, `_3_germline`    | `sample1_germline`, `_germline_2`, `_germline_3` |
| somatic (3 runs)  | `sample1_2_somatic`, `_2_2_somatic`, `_3_2_somatic` | `sample1_somatic`, `_somatic_2`, `_somatic_3`    |

## Changes

- `R/Tool.R`: rename the hook to `refine_files` and run it earlier, before the
  automatic `_2`/`_3` numbering. Default behaviour is unchanged (does nothing).
- `inst/doc-templates/vignettes/_output_naming.qmd`: the shared vignette content
  (walks through the naming scheme with the example `Tool1`).
- `vignettes/output_naming.qmd`: the vignette page itself, which pulls in the
  shared content above.
- `vignettes/structure.Rmd`: links across to the new vignette.
- `tests/testthat/test-Tool.R`: adds `refine_files` tests: default is a no-op, the hook runs before the `_2`/`_3` disambiguation passes, and a subclass can split a shared prefix apart to avoid a spurious `_2`.

## Compatibility

`refine_files` is an internal hook. The only tools using it are `Linx` and
`Purple` in tidywigits, updated separately (see below). No user-facing API
changes.

## tidywigits

tidywigits relies on this. Its `Linx` and `Purple` tools are updated to use the
renamed hook and the new timing to give germline vs somatic outputs consistent
names, and it adds its own Output Naming vignette building on this one.
