### PR TITLE
tool: bamtools_genecvg_genes => bamtools_genecvggenes (again!)

### DIFF
--- a/R/Tool.R
+++ b/R/Tool.R
@@ -466,7 +466,7 @@ Tool <- R6::R6Class(
           tbl_name = dplyr::if_else(
             .data$parser == .data$tidy_name,
             .data$tool_parser,
-            paste(.data$tool_parser, .data$tidy_name, sep = "_")
+            paste0(.data$tool_parser, .data$tidy_name)
           ),
           fpfix = paste(file.path(output_dir, .data$prefix), .data$tbl_name, sep = "_"),
           tidy_data = purrr::pmap(


### PR DESCRIPTION
Think this was an accidental regression (originally done in https://github.com/tidywf/nemo/commit/c3127bc91eb5e02c179c28134af0ded3302f6950, then reverted within the big refactor in https://github.com/tidywf/nemo/commit/f6660d6cd7be74ef93fae0cd725e0abf551f6243).
See diff below:

```
L2501721_bamtools_genecvg_cvg.parquet
L2501721_bamtools_genecvg_genes.parquet
L2501722_bamtools_genecvg_cvg.parquet
L2501722_bamtools_genecvg_genes.parquet
```

vs. now:

```
sample1_bamtools_genecvgcvg.parquet
sample1_bamtools_genecvggenes.parquet
sample1_somatic_sage_genecvgcvg.parquet
sample1_somatic_sage_genecvggenes.parquet
sample2_germline_sage_genecvgcvg.parquet
sample2_germline_sage_genecvggenes.parquet
```